### PR TITLE
Add lesson planning workflow

### DIFF
--- a/src/lib/server/db/service/coursemap.ts
+++ b/src/lib/server/db/service/coursemap.ts
@@ -413,15 +413,36 @@ export async function getCourseMapItemPlanContexts(
 }
 
 export async function createLessonPlanStandard(lessonPlanId: number, standardId: number) {
-	const [standard] = await db
-		.insert(table.lessonPlanLearningAreaStandard)
-		.values({
-			courseMapItemLessonPlanId: lessonPlanId,
-			learningAreaStandardId: standardId
-		})
-		.returning();
+        const [standard] = await db
+                .insert(table.lessonPlanLearningAreaStandard)
+                .values({
+                        courseMapItemLessonPlanId: lessonPlanId,
+                        learningAreaStandardId: standardId
+                })
+                .returning();
 
-	return standard;
+        return standard;
+}
+
+export async function getLessonPlanLearningAreaStandards(lessonPlanId: number) {
+        const standards = await db
+                .select({ learningAreaStandard: table.learningAreaStandard })
+                .from(table.lessonPlanLearningAreaStandard)
+                .innerJoin(
+                        table.learningAreaStandard,
+                        eq(
+                                table.learningAreaStandard.id,
+                                table.lessonPlanLearningAreaStandard.learningAreaStandardId
+                        )
+                )
+                .where(
+                        eq(
+                                table.lessonPlanLearningAreaStandard.courseMapItemLessonPlanId,
+                                lessonPlanId
+                        )
+                );
+
+        return standards.map((row) => row.learningAreaStandard);
 }
 
 export async function deleteCoursemapItemLessonPlan(lessonPlanId: number) {

--- a/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/+page.server.ts
+++ b/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/+page.server.ts
@@ -1,0 +1,33 @@
+import {
+        getCourseMapItemById,
+        getCourseMapItemLearningAreas,
+        getCoursemapItemLessonPlans,
+        getCoursemapItemAssessmentPlans
+} from '$lib/server/db/service/coursemap';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({
+        locals: { security },
+        params: { subjectOfferingId, courseMapItemId }
+}) => {
+        security.isAuthenticated();
+
+        const cmId = parseInt(courseMapItemId);
+
+        const courseMapItem = await getCourseMapItemById(cmId);
+        if (!courseMapItem) throw redirect(302, `/subjects/${subjectOfferingId}/curriculum`);
+
+        const [learningAreas, lessonPlans, assessmentPlans] = await Promise.all([
+                getCourseMapItemLearningAreas(cmId),
+                getCoursemapItemLessonPlans(cmId),
+                getCoursemapItemAssessmentPlans(cmId)
+        ]);
+
+        return {
+                subjectOfferingId: parseInt(subjectOfferingId),
+                courseMapItem,
+                learningAreas,
+                lessonPlans,
+                assessmentPlans
+        };
+};

--- a/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/+page.svelte
+++ b/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/+page.svelte
@@ -1,0 +1,78 @@
+<script lang="ts">
+        import * as Card from '$lib/components/ui/card';
+       import { Dialog, DialogContent, DialogTrigger, DialogTitle } from '$lib/components/ui/dialog';
+       import { Textarea } from '$lib/components/ui/textarea';
+       import { Button } from '$lib/components/ui/button';
+       import { page } from '$app/state';
+       let { data } = $props();
+       let instruction = $state('');
+</script>
+
+<div class="p-6 space-y-8">
+        <div class="space-y-2">
+                <h1 class="text-3xl font-bold">Planning</h1>
+                <h2 class="text-xl font-semibold">{data.courseMapItem.topic}</h2>
+                {#if data.courseMapItem.description}
+                        <p class="text-muted-foreground">{data.courseMapItem.description}</p>
+                {/if}
+                {#if data.learningAreas.length > 0}
+                        <div class="flex flex-wrap gap-2">
+                                {#each data.learningAreas as la}
+                                        <span class="text-sm bg-muted px-2 py-1 rounded">{la.name}</span>
+                                {/each}
+                        </div>
+                {/if}
+        </div>
+
+       <div class="flex justify-between items-center">
+               <h3 class="text-2xl font-semibold">Lesson Plans</h3>
+               <DialogTrigger asChild>
+                       <Button>New Plan</Button>
+               </DialogTrigger>
+       </div>
+        {#if data.lessonPlans.length > 0}
+                <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+                        {#each data.lessonPlans as plan}
+                                <a href={`${page.url.pathname}/${plan.id}`} class="block">
+                                        <Card.Root class="hover:shadow">
+                                                <Card.Header>
+                                                        <Card.Title>{plan.name}</Card.Title>
+                                                </Card.Header>
+                                        </Card.Root>
+                                </a>
+                        {/each}
+                </div>
+        {:else}
+                <p class="text-muted-foreground italic">No lesson plans</p>
+        {/if}
+
+        <div class="mt-8 space-y-4">
+                <h3 class="text-2xl font-semibold">Assessment Plans</h3>
+                {#if data.assessmentPlans.length > 0}
+                        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+                                {#each data.assessmentPlans as ap}
+                                        <Card.Root>
+                                                <Card.Header>
+                                                        <Card.Title>{ap.name}</Card.Title>
+                                                </Card.Header>
+                                        </Card.Root>
+                                {/each}
+                        </div>
+                {:else}
+                        <p class="text-muted-foreground italic">No assessment plans</p>
+                {/if}
+        </div>
+</div>
+
+<Dialog>
+        <DialogContent class="max-w-lg">
+                <DialogTitle class="mb-4">Create Lesson Plan</DialogTitle>
+                <form method="POST" action="new/lessonPlan?/create" class="space-y-4">
+                        <div>
+                                <label class="block text-sm font-medium mb-1" for="instruction">Optional Instructions</label>
+                                <Textarea id="instruction" name="instruction" bind:value={instruction} class="min-h-32" />
+                        </div>
+                        <Button type="submit">Generate</Button>
+                </form>
+        </DialogContent>
+</Dialog>

--- a/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/[courseMapItemLessonPlanId]/+page.server.ts
+++ b/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/[courseMapItemLessonPlanId]/+page.server.ts
@@ -1,0 +1,34 @@
+import {
+        getCourseMapItemById,
+        getCoursemapItemLessonPlan,
+        getLessonPlanLearningAreaStandards
+} from '$lib/server/db/service/coursemap';
+import { redirect } from '@sveltejs/kit';
+
+export const load = async ({
+        locals: { security },
+        params: { subjectOfferingId, courseMapItemId, courseMapItemLessonPlanId }
+}) => {
+        security.isAuthenticated();
+
+        const cmId = parseInt(courseMapItemId);
+        const planId = parseInt(courseMapItemLessonPlanId);
+
+        const [courseMapItem, lessonPlan] = await Promise.all([
+                getCourseMapItemById(cmId),
+                getCoursemapItemLessonPlan(planId)
+        ]);
+
+        if (!courseMapItem || !lessonPlan) {
+                throw redirect(302, `/subjects/${subjectOfferingId}/curriculum/${courseMapItemId}/planning`);
+        }
+
+        const standards = await getLessonPlanLearningAreaStandards(planId);
+
+        return {
+                subjectOfferingId: parseInt(subjectOfferingId),
+                courseMapItem,
+                lessonPlan,
+                standards
+        };
+};

--- a/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/[courseMapItemLessonPlanId]/+page.svelte
+++ b/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/[courseMapItemLessonPlanId]/+page.svelte
@@ -1,0 +1,58 @@
+<script lang="ts">
+        import * as Card from '$lib/components/ui/card';
+        import { page } from '$app/state';
+        let { data } = $props();
+</script>
+
+<div class="p-6 space-y-6">
+        <div>
+                <h1 class="text-3xl font-bold mb-2">{data.lessonPlan.name}</h1>
+                <p class="text-muted-foreground">Topic: {data.courseMapItem.topic}</p>
+        </div>
+
+        {#if data.lessonPlan.description}
+                <Card.Root>
+                        <Card.Header>
+                                <Card.Title>Description</Card.Title>
+                        </Card.Header>
+                        <Card.Content class="prose max-w-none">
+                                {data.lessonPlan.description}
+                        </Card.Content>
+                </Card.Root>
+        {/if}
+
+        {#if data.lessonPlan.scope?.length}
+                <Card.Root>
+                        <Card.Header>
+                                <Card.Title>Scopes</Card.Title>
+                        </Card.Header>
+                        <Card.Content>
+                                <ul class="list-disc ml-6 space-y-1">
+                                        {#each data.lessonPlan.scope as s}
+                                                <li>{s}</li>
+                                        {/each}
+                                </ul>
+                        </Card.Content>
+                </Card.Root>
+        {/if}
+
+        {#if data.standards.length > 0}
+                <Card.Root>
+                        <Card.Header>
+                                <Card.Title>Learning Area Standards</Card.Title>
+                        </Card.Header>
+                        <Card.Content>
+                                <ul class="list-disc ml-6 space-y-2">
+                                        {#each data.standards as std}
+                                                <li>
+                                                        <div class="font-medium">{std.name}</div>
+                                                        {#if std.description}
+                                                                <div class="text-sm">{std.description}</div>
+                                                        {/if}
+                                                </li>
+                                        {/each}
+                                </ul>
+                        </Card.Content>
+                </Card.Root>
+        {/if}
+</div>

--- a/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/new/lessonPlan/+page.server.ts
+++ b/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/new/lessonPlan/+page.server.ts
@@ -1,0 +1,53 @@
+import { redirect, fail } from '@sveltejs/kit';
+import {
+        createCourseMapItemLessonPlan,
+        createLessonPlanStandard,
+        getCourseMapItemPlanContexts
+} from '$lib/server/db/service/coursemap';
+import { geminiCompletion } from '$lib/server/ai';
+import { planSchema, buildLessonPlanPrompt } from '$lib/server/planSchema';
+
+export const load = async ({ locals: { security } }) => {
+        security.isAuthenticated();
+        return {};
+};
+
+export const actions = {
+        create: async ({ request, params, locals: { security } }) => {
+                security.isAuthenticated();
+
+                const courseMapItemId = parseInt(params.courseMapItemId);
+                const formData = await request.formData();
+                const instruction = (formData.get('instruction') as string) || '';
+
+                const contexts = await getCourseMapItemPlanContexts(courseMapItemId);
+                const prompt = buildLessonPlanPrompt(JSON.stringify(contexts), instruction);
+                const aiResponse = await geminiCompletion(prompt, undefined, planSchema);
+
+                let plan;
+                try {
+                        plan = JSON.parse(aiResponse);
+                } catch (err) {
+                        console.error('Failed to parse AI response', err, aiResponse);
+                        return fail(500, { message: 'Failed to generate lesson plan' });
+                }
+
+                const lessonPlan = await createCourseMapItemLessonPlan(
+                        courseMapItemId,
+                        plan.name,
+                        plan.scopes.map((s: { title: string; details: string }) => `${s.title}: ${s.details}`),
+                        plan.description
+                );
+
+                if (Array.isArray(plan.usedStandards)) {
+                        for (const std of plan.usedStandards) {
+                                if (std?.id) await createLessonPlanStandard(lessonPlan.id, std.id);
+                        }
+                }
+
+                throw redirect(
+                        303,
+                        `/subjects/${params.subjectOfferingId}/curriculum/${params.courseMapItemId}/planning/${lessonPlan.id}`
+                );
+        }
+};

--- a/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/new/lessonPlan/+page.svelte
+++ b/src/routes/subjects/[subjectOfferingId]/curriculum/[courseMapItemId]/planning/new/lessonPlan/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+        import { Textarea } from '$lib/components/ui/textarea';
+        import { Button } from '$lib/components/ui/button';
+        let { data } = $props();
+</script>
+
+<div class="p-6 max-w-xl mx-auto space-y-4">
+        <h1 class="text-2xl font-bold">Generate Lesson Plan</h1>
+        <form method="POST" action="?/create" class="space-y-4">
+                <div>
+                        <label class="block text-sm font-medium mb-1" for="instruction">Optional Instructions</label>
+                        <Textarea id="instruction" name="instruction" class="min-h-32" />
+                </div>
+                <Button type="submit">Generate</Button>
+        </form>
+</div>


### PR DESCRIPTION
## Summary
- implement lesson plan storage helpers
- show course map item planning information
- support AI generation of lesson plans
- render lesson plan detail page
- refine lesson plan dialog

## Testing
- `npm run lint` *(fails: Cannot find package 'prettier-plugin-svelte')*
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68779ff078688323866e96f26a91b9a5