### PR TITLE
feat: add whiteboard canvas engine, shapes and control points

### DIFF
--- a/docs/whiteboard/component-details/canvas-actions.md
+++ b/docs/whiteboard/component-details/canvas-actions.md
@@ -1,0 +1,345 @@
+# Canvas Actions Reference
+
+This document describes the action functions that perform operations on the whiteboard canvas.
+
+## Overview
+
+Canvas actions are stateless functions that perform specific operations on the canvas. They receive a `CanvasActionContext` containing the canvas instance and callbacks.
+
+## Action Context
+
+```typescript
+interface CanvasActionContext {
+	canvas: fabric.Canvas;
+	sendCanvasUpdate: (data: Record<string, unknown>) => void;
+	onImageAdded?: (img: fabric.FabricImage) => void;
+	socket?: any;
+	controlPointManager?: ControlPointManager;
+	onClearComplete?: (
+		deletedObjects: Array<{ id: string; data: Record<string, unknown> }>,
+	) => void;
+	setClearingCanvas?: (value: boolean) => void;
+	onLayerChange?: (
+		objectId: string,
+		previousIndex: number,
+		newIndex: number,
+	) => void;
+}
+```
+
+---
+
+## Image Actions
+
+### `handleImageUpload(file, ctx)`
+
+Handles uploading and adding an image to the canvas.
+
+```typescript
+async function handleImageUpload(
+	file: File,
+	ctx: CanvasActionContext,
+): Promise<fabric.FabricImage | null>;
+```
+
+**Process:**
+
+1. Read file as data URL using FileReader
+2. Create Fabric.js Image from data URL
+3. Assign unique ID
+4. Scale to fit reasonable size (max 800px)
+5. Center on canvas viewport
+6. Add to canvas with center origin
+7. Send to server
+8. Call `onImageAdded` callback
+
+**Example:**
+
+```typescript
+const file = event.target.files[0];
+const image = await handleImageUpload(file, ctx);
+if (image) {
+	canvas.setActiveObject(image);
+}
+```
+
+---
+
+## Clear Actions
+
+### `clearCanvas(ctx)`
+
+Clears all objects from the canvas.
+
+```typescript
+function clearCanvas(ctx: CanvasActionContext): void;
+```
+
+**Process:**
+
+1. Collect all deletable objects (excluding control points)
+2. Store object data for history
+3. Remove all control points
+4. Remove all objects
+5. Send batch delete to server
+6. Call `onClearComplete` with deleted objects
+
+**Note:** The `setClearingCanvas` callback prevents history recording during clear, since clear is recorded as a single batch operation.
+
+---
+
+## Delete Actions
+
+### `deleteSelectedObjects(ctx)`
+
+Deletes all currently selected objects.
+
+```typescript
+function deleteSelectedObjects(
+	ctx: CanvasActionContext,
+): Array<{ id: string; data: Record<string, unknown> }>;
+```
+
+**Returns:** Array of deleted object info for history recording.
+
+**Process:**
+
+1. Get active objects from selection
+2. For each object (excluding control points):
+   - Remove associated control points
+   - Collect object data for history
+   - Remove from canvas
+3. Discard active selection
+4. Send batch delete to server
+5. Return deleted objects array
+
+---
+
+## Zoom Actions
+
+### `zoomIn(ctx)`
+
+Increases zoom level by the configured step.
+
+```typescript
+function zoomIn(ctx: CanvasActionContext): number;
+```
+
+**Returns:** New zoom level.
+
+**Implementation:**
+
+```typescript
+const currentZoom = canvas.getZoom();
+const newZoom = Math.min(currentZoom * ZOOM_LIMITS.step, ZOOM_LIMITS.max);
+canvas.zoomToPoint(canvas.getCenterPoint(), newZoom);
+return newZoom;
+```
+
+### `zoomOut(ctx)`
+
+Decreases zoom level by the configured step.
+
+```typescript
+function zoomOut(ctx: CanvasActionContext): number;
+```
+
+**Returns:** New zoom level.
+
+### `resetZoom(ctx)`
+
+Resets zoom to 100% (1.0).
+
+```typescript
+function resetZoom(ctx: CanvasActionContext): number;
+```
+
+**Returns:** 1.0
+
+### `recenterView(ctx)`
+
+Resets viewport to origin (0,0) with current zoom maintained.
+
+```typescript
+function recenterView(ctx: CanvasActionContext): void;
+```
+
+**Implementation:**
+
+```typescript
+const vpt = canvas.viewportTransform;
+vpt[4] = 0; // Reset X translation
+vpt[5] = 0; // Reset Y translation
+canvas.setViewportTransform(vpt);
+```
+
+---
+
+## Layer Actions
+
+Layer actions change the z-index (stacking order) of objects.
+
+### `bringToFront(ctx)`
+
+Moves selected object to the top of the stack.
+
+```typescript
+function bringToFront(ctx: CanvasActionContext): void;
+```
+
+**Server sync:** Sends `layer` message with `action: 'bringToFront'`.
+
+### `sendToBack(ctx)`
+
+Moves selected object to the bottom of the stack.
+
+```typescript
+function sendToBack(ctx: CanvasActionContext): void;
+```
+
+**Server sync:** Sends `layer` message with `action: 'sendToBack'`.
+
+### `moveForward(ctx)`
+
+Moves selected object one step up in the stack.
+
+```typescript
+function moveForward(ctx: CanvasActionContext): void;
+```
+
+**Server sync:** Sends `layer` message with `action: 'moveForward'`.
+
+### `moveBackward(ctx)`
+
+Moves selected object one step down in the stack.
+
+```typescript
+function moveBackward(ctx: CanvasActionContext): void;
+```
+
+**Server sync:** Sends `layer` message with `action: 'moveBackward'`.
+
+### Layer Action Flow
+
+```typescript
+function bringToFront(ctx: CanvasActionContext): void {
+	const activeObject = ctx.canvas.getActiveObject();
+	if (!activeObject || ctx.controlPointManager?.isControlPoint(activeObject))
+		return;
+
+	const previousIndex = ctx.canvas.getObjects().indexOf(activeObject);
+	ctx.canvas.bringObjectToFront(activeObject);
+	const newIndex = ctx.canvas.getObjects().indexOf(activeObject);
+
+	// Ensure control points stay on top
+	ctx.controlPointManager?.bringAllControlPointsToFront();
+
+	// Notify for history recording
+	ctx.onLayerChange?.(activeObject.id, previousIndex, newIndex);
+
+	// Sync with server
+	ctx.sendCanvasUpdate({
+		type: 'layer',
+		object: { id: activeObject.id },
+		action: 'bringToFront',
+	});
+}
+```
+
+---
+
+## Opacity Actions
+
+### `applyOpacity(object, opacity, ctx)`
+
+Applies opacity to an object and syncs with server.
+
+```typescript
+function applyOpacity(
+	object: fabric.Object,
+	opacity: number,
+	ctx: CanvasActionContext,
+): void;
+```
+
+**Parameters:**
+
+- `object`: The target object
+- `opacity`: Value from 0 to 1
+- `ctx`: Action context
+
+**Implementation:**
+
+```typescript
+function applyOpacity(object, opacity, ctx) {
+	object.set({ opacity });
+	object.setCoords();
+	ctx.canvas.renderAll();
+
+	const objData = object.toObject();
+	objData.id = object.id;
+	ctx.sendCanvasUpdate({ type: 'modify', object: objData });
+}
+```
+
+---
+
+## Utility Functions
+
+### `hexToRgba(hex, alpha)`
+
+Converts hex color to rgba string.
+
+```typescript
+function hexToRgba(hex: string, alpha: number): string;
+```
+
+**Example:**
+
+```typescript
+hexToRgba('#ff0000', 0.5); // 'rgba(255, 0, 0, 0.5)'
+```
+
+### `calculateDistance(x1, y1, x2, y2)`
+
+Calculates Euclidean distance between two points.
+
+```typescript
+function calculateDistance(
+	x1: number,
+	y1: number,
+	x2: number,
+	y2: number,
+): number;
+```
+
+---
+
+## Action Usage Example
+
+```typescript
+// In the page component
+const actionContext: CanvasActionContext = {
+	canvas,
+	sendCanvasUpdate: (data) => socket.emit(data.type, { ...data, whiteboardId }),
+	controlPointManager,
+	onLayerChange: (objectId, prevIndex, newIndex) => {
+		history.recordLayer(objectId, prevIndex, newIndex, userId);
+	},
+	onClearComplete: (deletedObjects) => {
+		history.recordBatchDelete(deletedObjects, userId);
+	},
+};
+
+// Use actions
+zoomIn(actionContext);
+deleteSelectedObjects(actionContext);
+bringToFront(actionContext);
+```
+
+---
+
+## Source Files
+
+- **Canvas Actions**: `src/lib/components/whiteboard/canvas-actions.ts`
+- **Utilities**: `src/lib/components/whiteboard/utils.ts`

--- a/docs/whiteboard/component-details/canvas-events.md
+++ b/docs/whiteboard/component-details/canvas-events.md
@@ -1,0 +1,391 @@
+# Canvas Event System
+
+This document describes the event handling system that processes user interactions on the whiteboard canvas.
+
+## Overview
+
+The canvas event system translates user mouse/touch interactions into canvas operations. All event handlers receive a `CanvasEventContext` object containing the current state and callbacks needed to process the event.
+
+## Event Handler Functions
+
+### `setupCanvasEventHandlers(canvas, ctx)`
+
+Main setup function that attaches all event listeners to the Fabric.js canvas.
+
+```typescript
+function setupCanvasEventHandlers(
+	canvas: fabric.Canvas,
+	ctx: CanvasEventContext,
+): void;
+```
+
+### Events Handled
+
+| Event               | Fabric Event          | Handler                   |
+| ------------------- | --------------------- | ------------------------- |
+| Mouse Down          | `mouse:down`          | `handleMouseDown`         |
+| Mouse Move          | `mouse:move`          | `handleMouseMove`         |
+| Mouse Up            | `mouse:up`            | `handleMouseUp`           |
+| Object Moving       | `object:moving`       | `handleObjectMoving`      |
+| Object Scaling      | `object:scaling`      | `handleObjectScaling`     |
+| Object Rotating     | `object:rotating`     | `handleObjectRotating`    |
+| Object Modified     | `object:modified`     | `handleObjectModified`    |
+| Selection Created   | `selection:created`   | `handleSelectionCreated`  |
+| Selection Updated   | `selection:updated`   | `handleSelectionUpdated`  |
+| Selection Cleared   | `selection:cleared`   | `handleSelectionCleared`  |
+| Text Changed        | `text:changed`        | `handleTextChanged`       |
+| Text Editing Exited | `text:editing:exited` | `handleTextEditingExited` |
+| Path Created        | `path:created`        | `handlePathCreated`       |
+
+---
+
+## Mouse Events
+
+### `handleMouseDown`
+
+Triggered when user presses mouse button on canvas.
+
+**Tool-specific behaviors:**
+
+| Tool   | Action                                 |
+| ------ | -------------------------------------- |
+| Pan    | Start panning, record initial position |
+| Line   | Start line drawing, create start point |
+| Shapes | Start shape drawing, create temp shape |
+| Text   | Start text creation at click point     |
+| Eraser | Begin eraser trail                     |
+| Select | Start selection (handled by Fabric.js) |
+| Crop   | Handle crop handle click               |
+
+**Control Point Detection:**
+
+```typescript
+// Check if clicking on a control point
+if (controlPointManager?.isControlPoint(target)) {
+	// Start dragging the control point
+	setIsDraggingControlPoint(true);
+	setDraggedControlPointId(target.id);
+}
+```
+
+### `handleMouseMove`
+
+Triggered during mouse movement.
+
+**Tool-specific behaviors:**
+
+| Tool   | Action                                               |
+| ------ | ---------------------------------------------------- |
+| Pan    | Update viewport transform                            |
+| Line   | Update line preview                                  |
+| Shapes | Resize temp shape preview                            |
+| Text   | Update text box size                                 |
+| Eraser | Check for objects under cursor, add to deletion list |
+| Crop   | Move crop handles                                    |
+
+**Throttling:**
+Image and live updates are throttled to prevent overwhelming the network:
+
+```typescript
+const now = Date.now();
+if (now - lastImageUpdateTime > IMAGE_THROTTLE_MS) {
+	sendImageUpdate(objectData);
+	lastImageUpdateTime = now;
+}
+```
+
+### `handleMouseUp`
+
+Triggered when user releases mouse button.
+
+**Tool-specific behaviors:**
+
+| Tool   | Action                             |
+| ------ | ---------------------------------- |
+| Pan    | End panning                        |
+| Line   | Finalize line, send to server      |
+| Shapes | Finalize shape, send to server     |
+| Text   | Finalize text box, enter edit mode |
+| Eraser | Delete all hovered objects         |
+| Crop   | Complete crop handle drag          |
+
+---
+
+## Object Events
+
+### `handleObjectMoving`
+
+Triggered continuously while dragging an object.
+
+**Responsibilities:**
+
+1. Update control point positions to follow object
+2. Send "live" updates (not persisted) for real-time sync
+3. Track movement for undo/redo
+
+```typescript
+function handleObjectMoving(e: fabric.TEvent, ctx: CanvasEventContext) {
+	const obj = e.target;
+	const objectId = obj.id;
+
+	// Update control points
+	ctx.controlPointManager?.updateControlPoints(objectId, obj);
+
+	// Send live update
+	ctx.sendCanvasUpdate({
+		type: 'modify',
+		object: { id: objectId, left: obj.left, top: obj.top },
+		live: true, // Not persisted to DB
+	});
+}
+```
+
+### `handleObjectScaling`
+
+Triggered during resize operations.
+
+**Behaviors:**
+
+- Updates control point positions
+- Sends live updates with new scale values
+- For images: maintains aspect ratio from corners
+
+### `handleObjectRotating`
+
+Triggered during rotation.
+
+**Behaviors:**
+
+- Updates control point positions
+- Rotation handle updates position relative to object center
+
+### `handleObjectModified`
+
+Triggered when object manipulation completes (mouse up after moving/scaling/rotating).
+
+**Responsibilities:**
+
+1. Record history for undo/redo
+2. Send final update to server (persisted)
+3. Sync UI state (floating menu, etc.)
+
+```typescript
+function handleObjectModified(e: fabric.TEvent, ctx: CanvasEventContext) {
+	const obj = e.target;
+	const objectData = obj.toObject();
+	objectData.id = obj.id;
+
+	// Send final (persisted) update
+	ctx.sendCanvasUpdate({
+		type: 'modify',
+		object: objectData,
+		live: false, // Will be persisted
+	});
+
+	// Record history
+	ctx.history?.recordModify(obj.id, beforeState, objectData, ctx.userId);
+}
+```
+
+---
+
+## Selection Events
+
+### `handleSelectionCreated`
+
+Triggered when one or more objects are selected.
+
+**Responsibilities:**
+
+1. Add control points for selected objects
+2. Update floating menu with selected object properties
+3. Sync selection state
+
+```typescript
+function handleSelectionCreated(e: fabric.TEvent, ctx: CanvasEventContext) {
+	const selection = e.selected || [];
+
+	selection.forEach((obj) => {
+		if (!ctx.controlPointManager?.isControlPoint(obj)) {
+			ctx.controlPointManager?.addControlPoints(obj.id, obj, true);
+		}
+	});
+}
+```
+
+### `handleSelectionUpdated`
+
+Triggered when selection changes (objects added/removed from selection).
+
+**Behaviors:**
+
+- Remove control points from deselected objects
+- Add control points to newly selected objects
+
+### `handleSelectionCleared`
+
+Triggered when all objects are deselected.
+
+**Responsibilities:**
+
+1. Remove all control points
+2. Reset floating menu
+3. Clear selection-related state
+
+---
+
+## Text Events
+
+### `handleTextChanged`
+
+Triggered while editing text content.
+
+**Behaviors:**
+
+- Auto-resize textbox to fit content
+- Send live updates for real-time sync
+- Update control points
+
+### `handleTextEditingExited`
+
+Triggered when user exits text editing mode (click outside, press Escape).
+
+**Responsibilities:**
+
+1. Handle empty text (delete if empty)
+2. Send final text update
+3. Record history
+4. Re-add control points
+
+```typescript
+function handleTextEditingExited(e: fabric.TEvent, ctx: CanvasEventContext) {
+	const textbox = e.target as fabric.Textbox;
+
+	if (!textbox.text || textbox.text.trim() === '') {
+		// Delete empty textbox
+		ctx.canvas.remove(textbox);
+		ctx.sendCanvasUpdate({ type: 'delete', objects: [{ id: textbox.id }] });
+	} else {
+		// Send final update
+		const textData = textbox.toObject(['text']);
+		textData.id = textbox.id;
+		ctx.sendCanvasUpdate({ type: 'modify', object: textData });
+	}
+}
+```
+
+---
+
+## Path Events
+
+### `handlePathCreated`
+
+Triggered when freehand drawing completes (path created).
+
+**Responsibilities:**
+
+1. Assign unique ID to path
+2. Apply opacity setting
+3. Disable default Fabric.js controls
+4. Send to server
+5. Record history
+
+```typescript
+function handlePathCreated(
+	e: fabric.TEvent<{ path: fabric.Path }>,
+	ctx: CanvasEventContext,
+) {
+	const path = e.path;
+	const pathId = uuidv4();
+
+	path.set({
+		id: pathId,
+		hasControls: false,
+		hasBorders: false,
+		opacity: ctx.getDrawOptions().opacity,
+	});
+
+	const pathData = path.toObject();
+	pathData.id = pathId;
+
+	ctx.sendCanvasUpdate({ type: 'add', object: pathData });
+	ctx.history?.recordAdd(pathId, pathData, ctx.userId);
+}
+```
+
+---
+
+## CanvasEventContext Interface
+
+The context object provides access to state and callbacks:
+
+```typescript
+interface CanvasEventContext {
+	// State getters
+	getSelectedTool: () => WhiteboardTool;
+	getIsPanning: () => boolean;
+	getIsDrawingLine: () => boolean;
+	getIsDrawingShape: () => boolean;
+	// ... more getters
+
+	// State setters
+	setIsPanning: (value: boolean) => void;
+	setIsDrawingLine: (value: boolean) => void;
+	// ... more setters
+
+	// Options getters
+	getTextOptions: () => TextOptions;
+	getShapeOptions: () => ShapeOptions;
+	getDrawOptions: () => DrawOptions;
+	getLineOptions: () => LineOptions;
+
+	// Callbacks
+	sendCanvasUpdate: (data: Record<string, unknown>) => void;
+	sendImageUpdate: (data: Record<string, unknown>) => void;
+	clearEraserState: () => void;
+
+	// Managers
+	controlPointManager?: ControlPointManager;
+	history?: CanvasHistory;
+
+	// User info
+	userId?: string;
+}
+```
+
+---
+
+## Event Flow Diagram
+
+```
+User Interaction
+      │
+      ▼
+┌──────────────┐
+│ Mouse Event  │
+└──────────────┘
+      │
+      ▼
+┌──────────────┐     ┌──────────────┐
+│ Tool Check   │────▶│ Tool Handler │
+└──────────────┘     └──────────────┘
+                            │
+              ┌─────────────┼─────────────┐
+              ▼             ▼             ▼
+        ┌──────────┐  ┌──────────┐  ┌──────────┐
+        │ Canvas   │  │ Control  │  │ WebSocket│
+        │ Update   │  │ Points   │  │ Sync     │
+        └──────────┘  └──────────┘  └──────────┘
+              │             │             │
+              ▼             ▼             ▼
+        ┌──────────┐  ┌──────────┐  ┌──────────┐
+        │ History  │  │ Render   │  │ Remote   │
+        │ Record   │  │ Canvas   │  │ Clients  │
+        └──────────┘  └──────────┘  └──────────┘
+```
+
+---
+
+## Source Files
+
+- **Event Handlers**: `src/lib/components/whiteboard/canvas-events.ts`

--- a/docs/whiteboard/component-details/control-points.md
+++ b/docs/whiteboard/component-details/control-points.md
@@ -1,0 +1,433 @@
+# Control Points System
+
+This document describes the custom control point system that provides interactive handles for reshaping objects on the whiteboard.
+
+## Overview
+
+Control points are draggable handles that appear when an object is selected, allowing users to resize, reshape, and rotate objects. They replace the default Fabric.js controls with a custom implementation that provides:
+
+- Consistent visual styling across object types
+- Object-specific resize behaviors
+- Rotation handles
+- Real-time synchronization of changes
+- Zoom-aware sizing
+
+## Key Principles
+
+### 1. Client-Side Only
+
+- Control points are NEVER synced across users
+- Each user sees their own control points when they select an object
+- Prevents visual clutter and sync conflicts
+
+### 2. On-Demand Creation
+
+- Created only when a user selects an object
+- NOT created automatically when loading from database
+- NOT created when receiving updates from other users
+
+### 3. Visibility Management
+
+- Only visible for the selected object(s)
+- Hidden when selection changes to another object
+- Removed when object is deleted
+
+---
+
+## Architecture
+
+### Class Hierarchy
+
+```
+ControlPointHandler (abstract base)
+├── LineControlPoints (polylines)
+├── BoundingBoxControlPoints (abstract)
+│   ├── RectangleControlPoints
+│   ├── EllipseControlPoints
+│   ├── TriangleControlPoints
+│   ├── TextboxControlPoints
+│   ├── ImageControlPoints
+│   └── PathControlPoints
+└── CropOverlay (special case for image cropping)
+
+ControlPointManager (central coordinator)
+```
+
+### Control Point Index Convention
+
+| Index | Position             | Purpose           |
+| ----- | -------------------- | ----------------- |
+| 0     | Top-left corner      | Diagonal resize   |
+| 1     | Top-right corner     | Diagonal resize   |
+| 2     | Bottom-right corner  | Diagonal resize   |
+| 3     | Bottom-left corner   | Diagonal resize   |
+| 8     | Top edge midpoint    | Vertical resize   |
+| 9     | Right edge midpoint  | Horizontal resize |
+| 10    | Bottom edge midpoint | Vertical resize   |
+| 11    | Left edge midpoint   | Horizontal resize |
+| 12    | Above top edge       | Rotation          |
+
+---
+
+## ControlPointManager API
+
+### Constructor
+
+```typescript
+const manager = new ControlPointManager(
+  canvas: fabric.Canvas,
+  sendCanvasUpdate?: (data: Record<string, unknown>) => void
+)
+```
+
+### Methods
+
+| Method                                     | Description                          |
+| ------------------------------------------ | ------------------------------------ |
+| `addControlPoints(objectId, obj, visible)` | Add control points for an object     |
+| `removeControlPoints(objectId)`            | Remove control points for an object  |
+| `hideControlPoints(objectId)`              | Hide control points (keep in memory) |
+| `showControlPoints(objectId)`              | Show hidden control points           |
+| `hideAllControlPoints()`                   | Hide all control points              |
+| `updateControlPoints(objectId, obj)`       | Update positions after object moves  |
+| `updateObjectFromControlPoint(cpId, x, y)` | Handle control point drag            |
+| `isControlPoint(obj)`                      | Check if object is a control point   |
+| `getAllControlPoints()`                    | Get all control point references     |
+| `bringAllControlPointsToFront()`           | Ensure control points render on top  |
+| `updateAllControlPointSizes()`             | Update sizes based on zoom           |
+
+---
+
+## Handler Classes
+
+### LineControlPoints
+
+Handles polylines (straight lines).
+
+**Control Points:**
+
+- Point 0: Start endpoint
+- Point N-1: End endpoint
+
+**Behavior:**
+
+- Dragging endpoints updates line geometry
+- Line is recreated with new points (not transformed)
+
+### RectangleControlPoints
+
+Handles rectangles with full bounding box controls.
+
+**Features:**
+
+- Corner resize (maintains position of opposite corner)
+- Edge resize (stretches single dimension)
+- Rotation handle
+- Works with rotated rectangles
+
+### EllipseControlPoints
+
+Handles ellipses/circles.
+
+**Features:**
+
+- Adjusts `rx` and `ry` radii
+- Edge handles change single axis
+- Corner handles scale proportionally
+- Rotation support
+
+### TriangleControlPoints
+
+Handles triangles.
+
+**Features:**
+
+- Same as rectangle (bounding box based)
+- Triangle scales within bounding box
+
+### TextboxControlPoints
+
+Handles text objects.
+
+**Special Behaviors:**
+
+- Horizontal resize reflows text
+- Vertical resize scales font size proportionally
+- Maintains readable text proportions
+- Rotation currently disabled (buggy)
+
+### ImageControlPoints
+
+Handles images.
+
+**Features:**
+
+- Corner resize maintains aspect ratio
+- Edge resize allows distortion
+- Supports clipped/cropped images
+- Rotation support
+
+### PathControlPoints
+
+Handles freehand drawings.
+
+**Status:** Currently disabled due to bugs.
+
+---
+
+## CropOverlay
+
+Special overlay for image cropping mode.
+
+### Usage
+
+```typescript
+const cropOverlay = new CropOverlay(canvas);
+
+// Start cropping
+cropOverlay.startCrop(image, (bounds) => {
+	console.log('Crop bounds changed:', bounds);
+});
+
+// Apply crop
+const result = cropOverlay.applyCrop();
+// result = { success: true, imageId: '...', cropData: {...} }
+
+// Or cancel
+cropOverlay.cancelCrop();
+```
+
+### Visual Elements
+
+- Dark overlay outside crop area
+- Dashed border showing crop rectangle
+- 4 corner handles + 4 edge handles
+
+---
+
+## Implementation Guide
+
+### Adding Control Points for a New Object Type
+
+#### Step 1: Create Handler Class
+
+```typescript
+export class MyShapeControlPoints extends BoundingBoxControlPoints {
+	addControlPoints(
+		objectId: string,
+		obj: fabric.Object,
+		visible: boolean = true,
+	): void {
+		const shape = obj as fabric.MyShape;
+		const matrix = shape.calcTransformMatrix();
+
+		// Calculate corner positions in local coordinates
+		const corners = [
+			{ x: -width / 2, y: -height / 2 }, // Top-left
+			{ x: width / 2, y: -height / 2 }, // Top-right
+			{ x: width / 2, y: height / 2 }, // Bottom-right
+			{ x: -width / 2, y: height / 2 }, // Bottom-left
+		];
+
+		// Transform to absolute coordinates
+		const absoluteCorners = corners.map((c) =>
+			fabric.util.transformPoint(new fabric.Point(c.x, c.y), matrix),
+		);
+
+		// Create corner control points
+		absoluteCorners.forEach((corner, index) => {
+			const circle = this.createControlPointCircle(
+				corner.x,
+				corner.y,
+				`${objectId}-cp-${index}`,
+				objectId,
+				index,
+				true, // selectable
+			);
+			circle.set({ visible });
+			this.canvas.add(circle);
+			this.controlPoints.push({ id, circle, objectId, pointIndex: index });
+		});
+
+		// Create edge midpoints, rotation handle, etc.
+		// ...
+
+		this.bringControlPointsToFront();
+	}
+
+	updateControlPoints(objectId: string, obj: fabric.Object): void {
+		// Recalculate positions and update circles
+	}
+
+	updateObjectFromControlPoint(cpId: string, newX: number, newY: number): void {
+		// Handle the resize/rotate logic
+	}
+}
+```
+
+#### Step 2: Register in ControlPointManager
+
+```typescript
+constructor(canvas: fabric.Canvas) {
+  // ...existing handlers...
+
+  const myShapeHandler = new MyShapeControlPoints(canvas)
+  this.handlers.set('myshape', myShapeHandler)  // fabric type name
+}
+```
+
+#### Step 3: Disable Fabric.js Controls
+
+In websocket handlers:
+
+```typescript
+obj.set({ hasControls: false, hasBorders: false });
+```
+
+---
+
+## Control Point Circle Properties
+
+```typescript
+const circle = new fabric.Circle({
+	radius: 6 * scale, // Zoom-adjusted
+	fill: 'oklch(0.6171 0.1375 39.0427)', // Brand orange
+	stroke: 'oklch(0.5171 0.1375 39.0427)', // Darker orange
+	strokeWidth: 2 * scale, // Zoom-adjusted
+	left: x,
+	top: y,
+	originX: 'center',
+	originY: 'center',
+	selectable: true, // Required for dragging
+	hasControls: false, // No nested controls
+	hasBorders: false, // No selection border
+	hoverCursor: 'move', // Cursor style
+	evented: true, // Receives events
+	excludeFromExport: true, // Not saved to JSON
+});
+
+// Custom identification properties
+circle.id = controlPointId;
+circle.isControlPoint = true;
+circle.linkedObjectId = objectId;
+circle.pointIndex = pointIndex;
+```
+
+---
+
+## Coordinate System Handling
+
+### Transformation Matrix
+
+Objects can be rotated, scaled, and positioned. Use the transformation matrix to convert between coordinate systems:
+
+```typescript
+// Get transformation matrix
+const matrix = obj.calcTransformMatrix();
+
+// Local to absolute
+const absolutePoint = fabric.util.transformPoint(
+	new fabric.Point(localX, localY),
+	matrix,
+);
+
+// For polylines, account for pathOffset
+const absolutePoint = fabric.util.transformPoint(
+	new fabric.Point(point.x - line.pathOffset.x, point.y - line.pathOffset.y),
+	matrix,
+);
+```
+
+### Object Reconstruction Pattern
+
+For complex changes, sometimes recreating the object is simpler:
+
+```typescript
+// Store properties
+const id = obj.id;
+const props = { stroke, strokeWidth, opacity, angle };
+
+// Remove old
+canvas.remove(obj);
+
+// Create new with updated geometry
+const newObj = new fabric.Rect({
+	id,
+	...newGeometry,
+	...props,
+	hasControls: false,
+	hasBorders: false,
+});
+
+canvas.add(newObj);
+controlPointManager.bringAllControlPointsToFront();
+```
+
+---
+
+## Zoom Handling
+
+Control points maintain constant visual size regardless of zoom:
+
+```typescript
+updateControlPointSizes(): void {
+  const zoom = this.canvas.getZoom()
+  const scale = 1 / zoom  // Inverse scale
+
+  this.controlPoints.forEach((cp) => {
+    cp.circle.set({
+      radius: 6 * scale,
+      strokeWidth: 2 * scale
+    })
+    cp.circle.setCoords()
+  })
+}
+```
+
+Call this in the zoom handler:
+
+```typescript
+canvas.on('mouse:wheel', (e) => {
+	// ... zoom logic ...
+	controlPointManager.updateAllControlPointSizes();
+});
+```
+
+---
+
+## Common Pitfalls
+
+| Problem                                  | Solution                                      |
+| ---------------------------------------- | --------------------------------------------- |
+| Control points appear on remote browsers | Return early in `object:moving` before sync   |
+| Stray control points left behind         | Update circle position immediately in handler |
+| Menu opens for control points            | Check `isControlPoint` in selection handlers  |
+| Options don't apply to linked object     | Find linked object via `linkedObjectId`       |
+| Blue borders on reload                   | Set `hasBorders: false` in load handler       |
+| Control points behind objects            | Call `bringAllControlPointsToFront()`         |
+
+---
+
+## Testing Checklist
+
+When implementing control points for a new object type:
+
+- [ ] Control points appear when object is selected
+- [ ] Control points disappear when deselecting
+- [ ] Control points disappear when selecting another object
+- [ ] Dragging control points reshapes the object correctly
+- [ ] Control points don't appear on other users' screens
+- [ ] No stray control points left behind after dragging
+- [ ] Object options menu stays open when clicking control points
+- [ ] Changing options works when control point is selected
+- [ ] No blue borders appear after page reload
+- [ ] Control points appear on top of all objects
+- [ ] Undo/redo works correctly (control points aren't in history)
+- [ ] Control points don't get saved to database
+- [ ] Control points resize correctly when zooming
+
+---
+
+## Source Files
+
+- **Control Points**: `src/lib/components/whiteboard/control-points.ts`

--- a/docs/whiteboard/component-details/history.md
+++ b/docs/whiteboard/component-details/history.md
@@ -1,0 +1,440 @@
+# Undo/Redo History System
+
+This document describes the history management system that enables undo/redo functionality in the whiteboard.
+
+## Overview
+
+The history system uses the **Command Pattern** to track all canvas modifications. Each action is recorded as a command that can be undone (reversed) and redone (reapplied).
+
+## Architecture
+
+### CanvasHistory Class
+
+Central class managing the undo/redo stacks.
+
+```typescript
+class CanvasHistory {
+	private undoStack: Command[] = [];
+	private redoStack: Command[] = [];
+	private maxSize: number = 50;
+}
+```
+
+### Command Structure
+
+```typescript
+interface Command {
+	type: 'add' | 'modify' | 'delete' | 'batch-delete' | 'layer';
+	objectId: string;
+	userId: string;
+	timestamp: number;
+	objectData: Record<string, unknown>;
+
+	// For modify commands
+	beforeState?: Record<string, unknown>;
+	afterState?: Record<string, unknown>;
+
+	// For batch-delete commands
+	batchObjects?: Array<{ id: string; data: Record<string, unknown> }>;
+
+	// For layer commands
+	previousIndex?: number;
+	newIndex?: number;
+}
+```
+
+---
+
+## Command Types
+
+### Add Command
+
+Records when an object is created.
+
+```typescript
+{
+  type: 'add',
+  objectId: 'uuid-123',
+  userId: 'user-456',
+  timestamp: Date.now(),
+  objectData: { /* serialized object */ }
+}
+```
+
+**Undo:** Delete the object
+**Redo:** Re-add the object
+
+### Modify Command
+
+Records when an object is changed (moved, resized, rotated, styled).
+
+```typescript
+{
+  type: 'modify',
+  objectId: 'uuid-123',
+  userId: 'user-456',
+  timestamp: Date.now(),
+  objectData: { id: 'uuid-123' },
+  beforeState: { left: 100, top: 100, ... },
+  afterState: { left: 200, top: 150, ... }
+}
+```
+
+**Undo:** Apply `beforeState`
+**Redo:** Apply `afterState`
+
+### Delete Command
+
+Records when an object is deleted.
+
+```typescript
+{
+  type: 'delete',
+  objectId: 'uuid-123',
+  userId: 'user-456',
+  timestamp: Date.now(),
+  objectData: { /* full serialized object */ }
+}
+```
+
+**Undo:** Re-add the object
+**Redo:** Delete the object again
+
+### Batch-Delete Command
+
+Records when multiple objects are deleted at once (clear canvas, multi-select delete).
+
+```typescript
+{
+  type: 'batch-delete',
+  objectId: 'batch-timestamp',
+  userId: 'user-456',
+  timestamp: Date.now(),
+  objectData: {},
+  batchObjects: [
+    { id: 'uuid-1', data: { /* object 1 */ } },
+    { id: 'uuid-2', data: { /* object 2 */ } },
+    // ...
+  ]
+}
+```
+
+**Undo:** Re-add all objects
+**Redo:** Delete all objects again
+
+### Layer Command
+
+Records when an object's z-index changes.
+
+```typescript
+{
+  type: 'layer',
+  objectId: 'uuid-123',
+  userId: 'user-456',
+  timestamp: Date.now(),
+  objectData: { id: 'uuid-123' },
+  previousIndex: 2,
+  newIndex: 5
+}
+```
+
+**Undo:** Move to `previousIndex`
+**Redo:** Move to `newIndex`
+
+---
+
+## CanvasHistory API
+
+### Recording Methods
+
+```typescript
+// Record object creation
+recordAdd(objectId: string, objectData: Record<string, unknown>, userId: string): void
+
+// Record object modification (call before and after)
+recordModifyStart(objectId: string, beforeState: Record<string, unknown>): void
+recordModifyEnd(objectId: string, afterState: Record<string, unknown>, userId: string): void
+
+// Record object deletion
+recordDelete(objectId: string, objectData: Record<string, unknown>, userId: string): void
+
+// Record batch deletion
+recordBatchDelete(
+  objects: Array<{ id: string; data: Record<string, unknown> }>,
+  userId: string
+): void
+
+// Record layer change
+recordLayer(
+  objectId: string,
+  previousIndex: number,
+  newIndex: number,
+  userId: string
+): void
+```
+
+### Navigation Methods
+
+```typescript
+// Check if undo/redo is available
+canUndo(): boolean
+canRedo(): boolean
+
+// Get commands for execution
+popUndo(): Command | undefined
+popRedo(): Command | undefined
+
+// Move command between stacks
+pushToRedo(command: Command): void
+pushToUndo(command: Command): void
+```
+
+### State Methods
+
+```typescript
+// Clear all history
+clear(): void
+
+// Get current stack sizes
+getUndoCount(): number
+getRedoCount(): number
+```
+
+---
+
+## Apply Functions
+
+### applyUndo
+
+Executes an undo operation on the canvas.
+
+```typescript
+async function applyUndo(
+	command: Command,
+	canvas: fabric.Canvas,
+	sendCanvasUpdate: (data: Record<string, unknown>) => void,
+	controlPointManager?: ControlPointManager,
+): Promise<void>;
+```
+
+### applyRedo
+
+Executes a redo operation on the canvas.
+
+```typescript
+async function applyRedo(
+	command: Command,
+	canvas: fabric.Canvas,
+	sendCanvasUpdate: (data: Record<string, unknown>) => void,
+	controlPointManager?: ControlPointManager,
+): Promise<void>;
+```
+
+---
+
+## Usage Example
+
+```typescript
+// Initialize history
+const history = new CanvasHistory();
+
+// Record an add
+const rectId = uuidv4();
+const rectData = rect.toObject();
+rectData.id = rectId;
+history.recordAdd(rectId, rectData, userId);
+
+// Record a modify (before + after)
+history.recordModifyStart(rectId, { left: 100, top: 100 });
+rect.set({ left: 200, top: 150 });
+history.recordModifyEnd(rectId, { left: 200, top: 150 }, userId);
+
+// Perform undo
+if (history.canUndo()) {
+	const command = history.popUndo();
+	await applyUndo(command, canvas, sendCanvasUpdate, controlPointManager);
+	history.pushToRedo(command);
+	updateHistoryState();
+}
+
+// Perform redo
+if (history.canRedo()) {
+	const command = history.popRedo();
+	await applyRedo(command, canvas, sendCanvasUpdate, controlPointManager);
+	history.pushToUndo(command);
+	updateHistoryState();
+}
+```
+
+---
+
+## Implementation Details
+
+### Per-User History
+
+History is tracked per-user. Commands include `userId` for potential future features like:
+
+- Showing who made each change
+- Filtering history by user
+- Collaborative undo (undo only your changes)
+
+### Stack Size Limit
+
+Default limit of 50 commands prevents memory issues:
+
+```typescript
+private addToUndoStack(command: Command): void {
+  this.undoStack.push(command)
+  if (this.undoStack.length > this.maxSize) {
+    this.undoStack.shift()  // Remove oldest
+  }
+  this.redoStack = []  // Clear redo on new action
+}
+```
+
+### Redo Stack Clearing
+
+When a new action is recorded, the redo stack is cleared. This prevents inconsistent states from branching history.
+
+### Control Points Exclusion
+
+Control points are client-side only and are NOT included in history:
+
+- They're excluded from object serialization
+- Undo/redo recreates objects without control points
+- Control points are re-added on selection
+
+---
+
+## Integration with Canvas Events
+
+### Recording Flow
+
+```
+User Action
+    │
+    ▼
+Canvas Event Handler
+    │
+    ├─── Before: recordModifyStart() ───▶ Store beforeState
+    │
+    ▼
+Apply Change to Canvas
+    │
+    ▼
+Object Modified Event
+    │
+    └─── After: recordModifyEnd() ───▶ Store afterState
+                                        Clear redo stack
+```
+
+### Example: Object Move
+
+```typescript
+// In object:moving handler - track start state
+handleObjectMoving(e) {
+  const obj = e.target
+  if (!movingObjectBeforeState.has(obj.id)) {
+    // First move event - store initial state
+    movingObjectBeforeState.set(obj.id, {
+      left: obj.left,
+      top: obj.top
+    })
+  }
+}
+
+// In object:modified handler - record complete action
+handleObjectModified(e) {
+  const obj = e.target
+  const beforeState = movingObjectBeforeState.get(obj.id)
+
+  if (beforeState) {
+    history.recordModifyStart(obj.id, beforeState)
+    history.recordModifyEnd(obj.id, {
+      left: obj.left,
+      top: obj.top
+    }, userId)
+
+    movingObjectBeforeState.delete(obj.id)
+  }
+}
+```
+
+---
+
+## UI Integration
+
+### Updating Button States
+
+```typescript
+function updateHistoryState() {
+	canUndoState = history.canUndo();
+	canRedoState = history.canRedo();
+}
+```
+
+### Keyboard Shortcuts
+
+```typescript
+// Ctrl+Z / Cmd+Z for undo
+if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
+	performUndo();
+}
+
+// Ctrl+Shift+Z / Cmd+Shift+Z for redo
+if ((e.ctrlKey || e.metaKey) && e.key === 'z' && e.shiftKey) {
+	performRedo();
+}
+
+// Ctrl+Y / Cmd+Y for redo (alternative)
+if ((e.ctrlKey || e.metaKey) && e.key === 'y') {
+	performRedo();
+}
+```
+
+---
+
+## Special Cases
+
+### Clear Canvas
+
+Clear is recorded as a single batch-delete command containing all deleted objects:
+
+```typescript
+function clearCanvas(ctx) {
+	const deletedObjects = [];
+
+	ctx.canvas.getObjects().forEach((obj) => {
+		if (!controlPointManager.isControlPoint(obj)) {
+			deletedObjects.push({ id: obj.id, data: obj.toObject() });
+		}
+	});
+
+	// Record before clearing
+	ctx.onClearComplete?.(deletedObjects); // Triggers recordBatchDelete
+
+	// Then clear
+	ctx.canvas.clear();
+}
+```
+
+### Paste Operations
+
+Pasted objects are recorded as individual add commands:
+
+```typescript
+async function pasteFromClipboard(ctx) {
+	for (const objData of clipboard) {
+		const newId = uuidv4();
+		// ... create object ...
+
+		ctx.history?.recordAdd(newId, sendData, ctx.userId);
+	}
+}
+```
+
+---
+
+## Source Files
+
+- **History System**: `src/lib/components/whiteboard/canvas-history.ts`

--- a/docs/whiteboard/component-details/keyboard-shortcuts.md
+++ b/docs/whiteboard/component-details/keyboard-shortcuts.md
@@ -1,0 +1,412 @@
+# Keyboard Shortcuts
+
+This document describes all keyboard shortcuts available in the whiteboard.
+
+## Overview
+
+Keyboard shortcuts are handled by the `setupKeyboardShortcuts` function, which attaches event listeners to the window for both `keydown` and `keyup` events.
+
+## Shortcut Reference
+
+### Tool Selection
+
+| Shortcut | Action        |
+| -------- | ------------- |
+| `V`      | Select tool   |
+| `H`      | Pan/Hand tool |
+| `P`      | Draw/Pen tool |
+| `L`      | Line tool     |
+| `T`      | Text tool     |
+| `E`      | Eraser tool   |
+
+### Editing
+
+| Shortcut               | Action                     |
+| ---------------------- | -------------------------- |
+| `Delete` / `Backspace` | Delete selected objects    |
+| `Ctrl+C` / `Cmd+C`     | Copy selected objects      |
+| `Ctrl+V` / `Cmd+V`     | Paste from clipboard       |
+| `Ctrl+D` / `Cmd+D`     | Duplicate selected objects |
+| `Ctrl+A` / `Cmd+A`     | Select all objects         |
+
+### History
+
+| Shortcut                       | Action             |
+| ------------------------------ | ------------------ |
+| `Ctrl+Z` / `Cmd+Z`             | Undo               |
+| `Ctrl+Shift+Z` / `Cmd+Shift+Z` | Redo               |
+| `Ctrl+Y` / `Cmd+Y`             | Redo (alternative) |
+
+### View
+
+| Shortcut           | Action             |
+| ------------------ | ------------------ |
+| `Ctrl++` / `Cmd++` | Zoom in            |
+| `Ctrl+-` / `Cmd+-` | Zoom out           |
+| `Ctrl+0` / `Cmd+0` | Reset zoom to 100% |
+| `Space` (hold)     | Temporary pan mode |
+
+---
+
+## Implementation
+
+### Setup Function
+
+```typescript
+function setupKeyboardShortcuts(
+	canvas: fabric.Canvas,
+	ctx: KeyboardShortcutContext,
+): () => void; // Returns cleanup function
+```
+
+### Context Interface
+
+```typescript
+interface KeyboardShortcutContext {
+  canvas: fabric.Canvas
+  sendCanvasUpdate: (data: Record<string, unknown>) => void
+  controlPointManager?: ControlPointManager
+  history?: {
+    recordAdd: (...) => void
+    recordDelete: (...) => void
+    canUndo: () => boolean
+    canRedo: () => boolean
+  }
+  userId?: string
+  updateHistoryState?: () => void
+  mousePosition?: { x: number; y: number }
+
+  // Tool switching
+  setSelectedTool?: (tool: WhiteboardTool) => void
+  getSelectedTool?: () => WhiteboardTool
+
+  // Clipboard
+  clipboard?: Record<string, unknown>[]
+  setClipboard?: (data: Record<string, unknown>[]) => void
+
+  // Callbacks
+  onUndo?: () => void
+  onRedo?: () => void
+}
+```
+
+---
+
+## Tool Shortcuts
+
+### Implementation Pattern
+
+```typescript
+function handleKeyDown(e: KeyboardEvent) {
+	// Skip if typing in input/textarea
+	if (isTextInputFocused()) return;
+
+	// Skip if modifier keys pressed (except for shortcuts)
+	if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+	switch (e.key.toLowerCase()) {
+		case 'v':
+			ctx.setSelectedTool?.('select');
+			break;
+		case 'h':
+			ctx.setSelectedTool?.('pan');
+			break;
+		case 'p':
+			ctx.setSelectedTool?.('draw');
+			break;
+		case 'l':
+			ctx.setSelectedTool?.('line');
+			break;
+		case 't':
+			ctx.setSelectedTool?.('text');
+			break;
+		case 'e':
+			ctx.setSelectedTool?.('eraser');
+			break;
+	}
+}
+```
+
+---
+
+## Delete Shortcut
+
+Deletes all selected objects.
+
+```typescript
+case 'Delete':
+case 'Backspace':
+  e.preventDefault()
+  const deleted = deleteSelectedObjects({
+    canvas,
+    sendCanvasUpdate: ctx.sendCanvasUpdate,
+    controlPointManager: ctx.controlPointManager
+  })
+
+  if (deleted.length > 0) {
+    if (deleted.length === 1) {
+      ctx.history?.recordDelete(deleted[0].id, deleted[0].data, ctx.userId)
+    } else {
+      ctx.history?.recordBatchDelete(deleted, ctx.userId)
+    }
+    ctx.updateHistoryState?.()
+  }
+  break
+```
+
+---
+
+## Clipboard Operations
+
+### Copy
+
+```typescript
+case 'c':
+  if (e.ctrlKey || e.metaKey) {
+    e.preventDefault()
+    const selection = canvas.getActiveObjects()
+    const clipboardData = selection
+      .filter(obj => !ctx.controlPointManager?.isControlPoint(obj))
+      .map(obj => {
+        const data = obj.toObject()
+        data.id = obj.id
+        return data
+      })
+    ctx.setClipboard?.(clipboardData)
+  }
+  break
+```
+
+### Paste
+
+```typescript
+case 'v':
+  if (e.ctrlKey || e.metaKey) {
+    e.preventDefault()
+    const clipboard = ctx.clipboard || []
+    if (clipboard.length === 0) return
+
+    const pastedObjects: fabric.Object[] = []
+
+    for (const objData of clipboard) {
+      const newId = uuidv4()
+
+      // Offset pasted objects slightly
+      const offset = 20
+      objData.left = (objData.left || 0) + offset
+      objData.top = (objData.top || 0) + offset
+
+      const newObj = await fabric.util.enlivenObjects([objData])
+      newObj[0].set({
+        id: newId,
+        hasControls: false,
+        hasBorders: false
+      })
+
+      canvas.add(newObj[0])
+      pastedObjects.push(newObj[0])
+
+      // Send to server
+      const sendData = newObj[0].toObject()
+      sendData.id = newId
+      ctx.sendCanvasUpdate({ type: 'add', object: sendData })
+
+      // Record history
+      ctx.history?.recordAdd(newId, sendData, ctx.userId)
+    }
+
+    // Select pasted objects
+    if (pastedObjects.length === 1) {
+      canvas.setActiveObject(pastedObjects[0])
+    } else if (pastedObjects.length > 1) {
+      const selection = new fabric.ActiveSelection(pastedObjects, { canvas })
+      canvas.setActiveObject(selection)
+    }
+
+    ctx.updateHistoryState?.()
+  }
+  break
+```
+
+### Duplicate
+
+```typescript
+case 'd':
+  if (e.ctrlKey || e.metaKey) {
+    e.preventDefault()
+    // Copy then paste in one operation
+    // Similar to copy + paste but with smaller offset
+  }
+  break
+```
+
+---
+
+## Select All
+
+```typescript
+case 'a':
+  if (e.ctrlKey || e.metaKey) {
+    e.preventDefault()
+
+    const selectableObjects = canvas.getObjects().filter(obj =>
+      !ctx.controlPointManager?.isControlPoint(obj) &&
+      obj.selectable !== false
+    )
+
+    if (selectableObjects.length > 0) {
+      canvas.discardActiveObject()
+      const selection = new fabric.ActiveSelection(selectableObjects, { canvas })
+      canvas.setActiveObject(selection)
+      canvas.requestRenderAll()
+    }
+  }
+  break
+```
+
+---
+
+## Undo/Redo
+
+```typescript
+case 'z':
+  if (e.ctrlKey || e.metaKey) {
+    e.preventDefault()
+    if (e.shiftKey) {
+      // Redo
+      ctx.onRedo?.()
+    } else {
+      // Undo
+      ctx.onUndo?.()
+    }
+  }
+  break
+
+case 'y':
+  if (e.ctrlKey || e.metaKey) {
+    e.preventDefault()
+    ctx.onRedo?.()
+  }
+  break
+```
+
+---
+
+## Zoom Shortcuts
+
+```typescript
+case '+':
+case '=':
+  if (e.ctrlKey || e.metaKey) {
+    e.preventDefault()
+    zoomIn({ canvas, sendCanvasUpdate: () => {} })
+    ctx.controlPointManager?.updateAllControlPointSizes()
+  }
+  break
+
+case '-':
+case '_':
+  if (e.ctrlKey || e.metaKey) {
+    e.preventDefault()
+    zoomOut({ canvas, sendCanvasUpdate: () => {} })
+    ctx.controlPointManager?.updateAllControlPointSizes()
+  }
+  break
+
+case '0':
+  if (e.ctrlKey || e.metaKey) {
+    e.preventDefault()
+    resetZoom({ canvas, sendCanvasUpdate: () => {} })
+    ctx.controlPointManager?.updateAllControlPointSizes()
+  }
+  break
+```
+
+---
+
+## Space Bar Pan Mode
+
+Holding Space temporarily switches to pan mode.
+
+```typescript
+let previousTool: WhiteboardTool | null = null;
+
+function handleKeyDown(e: KeyboardEvent) {
+	if (e.code === 'Space' && !e.repeat) {
+		e.preventDefault();
+		previousTool = ctx.getSelectedTool?.() || 'select';
+		ctx.setSelectedTool?.('pan');
+	}
+}
+
+function handleKeyUp(e: KeyboardEvent) {
+	if (e.code === 'Space') {
+		e.preventDefault();
+		if (previousTool) {
+			ctx.setSelectedTool?.(previousTool);
+			previousTool = null;
+		}
+	}
+}
+```
+
+---
+
+## Text Input Detection
+
+Shortcuts are disabled when typing in text fields:
+
+```typescript
+function isTextInputFocused(): boolean {
+	const active = document.activeElement;
+	if (!active) return false;
+
+	const tagName = active.tagName.toLowerCase();
+	if (tagName === 'input' || tagName === 'textarea') return true;
+
+	// Check for contenteditable
+	if (active.getAttribute('contenteditable') === 'true') return true;
+
+	// Check if editing text in Fabric.js
+	const editingText = canvas.getActiveObject();
+	if (editingText && editingText.type === 'textbox' && editingText.isEditing) {
+		return true;
+	}
+
+	return false;
+}
+```
+
+---
+
+## Cleanup
+
+The setup function returns a cleanup function to remove event listeners:
+
+```typescript
+function setupKeyboardShortcuts(canvas, ctx) {
+  const handleKeyDown = (e: KeyboardEvent) => { ... }
+  const handleKeyUp = (e: KeyboardEvent) => { ... }
+
+  window.addEventListener('keydown', handleKeyDown)
+  window.addEventListener('keyup', handleKeyUp)
+
+  // Return cleanup function
+  return () => {
+    window.removeEventListener('keydown', handleKeyDown)
+    window.removeEventListener('keyup', handleKeyUp)
+  }
+}
+
+// Usage in component
+onMount(() => {
+  const cleanup = setupKeyboardShortcuts(canvas, ctx)
+  return cleanup  // Called on unmount
+})
+```
+
+---
+
+## Source Files
+
+- **Keyboard Shortcuts**: `src/lib/components/whiteboard/keyboard-shortcuts.ts`

--- a/docs/whiteboard/component-details/shapes.md
+++ b/docs/whiteboard/component-details/shapes.md
@@ -1,0 +1,403 @@
+# Shape Factory Functions
+
+This document describes the shape creation utilities used for programmatically creating Fabric.js objects.
+
+## Overview
+
+The `shapes.ts` module provides factory functions for creating canvas objects with consistent default properties. These functions are used when:
+
+- Drawing shapes interactively
+- Pasting objects from clipboard
+- Undoing deletions (recreating objects)
+- Loading from database
+
+## Factory Functions
+
+### createRectangle
+
+Creates a rectangle with configurable properties.
+
+```typescript
+function createRectangle(
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+	options?: Partial<ShapeOptions>,
+): fabric.Rect;
+```
+
+**Parameters:**
+
+- `x, y`: Top-left corner position
+- `width, height`: Dimensions
+- `options`: Optional style overrides
+
+**Returns:** `fabric.Rect` instance
+
+**Example:**
+
+```typescript
+const rect = createRectangle(100, 100, 200, 150, {
+	fillColour: '#3498db',
+	strokeColour: '#2980b9',
+	strokeWidth: 3,
+	opacity: 0.8,
+});
+rect.id = uuidv4();
+canvas.add(rect);
+```
+
+### createCircle
+
+Creates an ellipse (or circle if equal radii).
+
+```typescript
+function createCircle(
+	x: number,
+	y: number,
+	rx: number,
+	ry: number,
+	options?: Partial<ShapeOptions>,
+): fabric.Ellipse;
+```
+
+**Parameters:**
+
+- `x, y`: Center position
+- `rx, ry`: Horizontal and vertical radii
+
+**Example:**
+
+```typescript
+// Circle (equal radii)
+const circle = createCircle(200, 200, 50, 50);
+
+// Ellipse
+const ellipse = createCircle(200, 200, 80, 40);
+```
+
+### createTriangle
+
+Creates an equilateral triangle.
+
+```typescript
+function createTriangle(
+	x: number,
+	y: number,
+	width: number,
+	height: number,
+	options?: Partial<ShapeOptions>,
+): fabric.Triangle;
+```
+
+### createLine
+
+Creates a polyline (2-point line).
+
+```typescript
+function createLine(
+	points: Array<{ x: number; y: number }>,
+	options?: Partial<LineOptions>,
+): fabric.Polyline;
+```
+
+**Example:**
+
+```typescript
+const line = createLine(
+	[
+		{ x: 100, y: 100 },
+		{ x: 300, y: 200 },
+	],
+	{ strokeWidth: 3, strokeColour: '#e74c3c', strokeDashArray: [10, 5] },
+);
+```
+
+### createTextbox
+
+Creates an editable textbox.
+
+```typescript
+function createTextbox(
+	text: string,
+	x: number,
+	y: number,
+	options?: Partial<TextOptions>,
+): fabric.Textbox;
+```
+
+**Example:**
+
+```typescript
+const textbox = createTextbox('Hello World', 100, 100, {
+	fontSize: 24,
+	fontFamily: 'Arial',
+	colour: '#333',
+	textAlign: 'center',
+});
+```
+
+### createPath
+
+Creates a path from SVG path data (for freehand drawings).
+
+```typescript
+function createPath(
+	pathData: string,
+	options?: {
+		stroke?: string;
+		strokeWidth?: number;
+		fill?: string;
+		opacity?: number;
+	},
+): fabric.Path;
+```
+
+---
+
+## Common Properties
+
+All factory functions apply these base properties:
+
+```typescript
+const baseProperties = {
+	originX: 'center',
+	originY: 'center',
+	hasControls: false, // Custom control points used
+	hasBorders: false, // No default selection border
+	lockScalingFlip: true,
+};
+```
+
+---
+
+## Shape Options
+
+### ShapeOptions Interface
+
+```typescript
+interface ShapeOptions {
+	strokeWidth: number;
+	strokeColour: string;
+	fillColour: string;
+	strokeDashArray: number[];
+	opacity: number;
+}
+```
+
+### Default Values
+
+```typescript
+const DEFAULT_SHAPE_OPTIONS: ShapeOptions = {
+	strokeWidth: 2,
+	strokeColour: '#4A5568',
+	fillColour: 'transparent',
+	strokeDashArray: [],
+	opacity: 1,
+};
+```
+
+### Dash Patterns
+
+| Pattern         | Description |
+| --------------- | ----------- |
+| `[]`            | Solid line  |
+| `[5, 5]`        | Even dashes |
+| `[10, 5]`       | Long dashes |
+| `[2, 2]`        | Dotted      |
+| `[10, 5, 2, 5]` | Dash-dot    |
+
+---
+
+## Line Options
+
+### LineOptions Interface
+
+```typescript
+interface LineOptions {
+	strokeWidth: number;
+	strokeColour: string;
+	strokeDashArray: number[];
+	opacity: number;
+}
+```
+
+### Polyline Structure
+
+Lines are created as `fabric.Polyline` for future extensibility (adding points):
+
+```typescript
+const line = new fabric.Polyline(
+	[
+		{ x: startX, y: startY },
+		{ x: endX, y: endY },
+	],
+	{
+		fill: 'transparent',
+		stroke: options.strokeColour,
+		strokeWidth: options.strokeWidth,
+		strokeDashArray: options.strokeDashArray,
+		opacity: options.opacity,
+		originX: 'center',
+		originY: 'center',
+		hasControls: false,
+		hasBorders: false,
+	},
+);
+```
+
+---
+
+## Text Options
+
+### TextOptions Interface
+
+```typescript
+interface TextOptions {
+	fontSize: number;
+	fontFamily: string;
+	fontWeight: string;
+	colour: string;
+	textAlign: string;
+	opacity: number;
+}
+```
+
+### Default Values
+
+```typescript
+const DEFAULT_TEXT_OPTIONS: TextOptions = {
+	fontSize: 16,
+	fontFamily: 'Arial',
+	fontWeight: 'normal',
+	colour: '#4A5568',
+	textAlign: 'left',
+	opacity: 1,
+};
+```
+
+### Available Font Families
+
+```typescript
+const FONT_FAMILIES = [
+	'Arial',
+	'Times New Roman',
+	'Courier New',
+	'Georgia',
+	'Verdana',
+	'Comic Sans MS',
+];
+```
+
+---
+
+## Object Serialization
+
+### toObject with ID
+
+When serializing objects, always include the custom `id`:
+
+```typescript
+const data = obj.toObject();
+data.id = obj.id;
+```
+
+### Fabric.js toObject Properties
+
+```typescript
+// Include custom properties in serialization
+fabric.Object.prototype.toObject = (function (toObject) {
+	return function (propertiesToInclude = []) {
+		return toObject.call(this, [...propertiesToInclude, 'id']);
+	};
+})(fabric.Object.prototype.toObject);
+```
+
+---
+
+## Recreating Objects
+
+### From Serialized Data
+
+```typescript
+async function recreateObject(
+	data: Record<string, unknown>,
+): Promise<fabric.Object> {
+	const [fabricObj] = await fabric.util.enlivenObjects([data]);
+
+	fabricObj.set({ id: data.id, hasControls: false, hasBorders: false });
+
+	return fabricObj;
+}
+```
+
+### Batch Recreation
+
+```typescript
+async function recreateObjects(
+	objects: Record<string, unknown>[],
+): Promise<fabric.Object[]> {
+	const results: fabric.Object[] = [];
+
+	for (const objData of objects) {
+		const fabricObj = await recreateObject(objData);
+		results.push(fabricObj);
+	}
+
+	return results;
+}
+```
+
+---
+
+## Usage in Interactive Drawing
+
+### Shape Drawing Flow
+
+```typescript
+// Mouse down - create temp shape
+function onMouseDown(e) {
+	const pointer = canvas.getPointer(e.e);
+	tempShape = createRectangle(pointer.x, pointer.y, 0, 0, currentOptions);
+	canvas.add(tempShape);
+}
+
+// Mouse move - update size
+function onMouseMove(e) {
+	const pointer = canvas.getPointer(e.e);
+	const width = pointer.x - startX;
+	const height = pointer.y - startY;
+
+	tempShape.set({
+		width: Math.abs(width),
+		height: Math.abs(height),
+		left: width > 0 ? startX : pointer.x,
+		top: height > 0 ? startY : pointer.y,
+	});
+	tempShape.setCoords();
+	canvas.renderAll();
+}
+
+// Mouse up - finalize
+function onMouseUp() {
+	const shapeId = uuidv4();
+	tempShape.set({ id: shapeId });
+
+	const shapeData = tempShape.toObject();
+	shapeData.id = shapeId;
+
+	sendCanvasUpdate({ type: 'add', object: shapeData });
+	history.recordAdd(shapeId, shapeData, userId);
+
+	tempShape = null;
+}
+```
+
+---
+
+## Source Files
+
+- **Shape Factories**: `src/lib/components/whiteboard/shapes.ts`
+- **Types**: `src/lib/components/whiteboard/types.ts`
+- **Constants**: `src/lib/components/whiteboard/constants.ts`

--- a/docs/whiteboard/component-details/tools.md
+++ b/docs/whiteboard/component-details/tools.md
@@ -1,0 +1,337 @@
+# Tools & Interactions Guide
+
+This document describes each tool available in the whiteboard toolbar and how they interact with the canvas.
+
+## Tool Overview
+
+| Tool      | Icon          | Keyboard | Description                         |
+| --------- | ------------- | -------- | ----------------------------------- |
+| Select    | Mouse pointer | `V`      | Select, move, and transform objects |
+| Pan       | Hand          | `H`      | Pan/scroll the canvas               |
+| Draw      | Pen           | `P`      | Freehand drawing with brush         |
+| Line      | Line          | `L`      | Draw straight lines                 |
+| Rectangle | Square        | -        | Draw rectangles                     |
+| Circle    | Circle        | -        | Draw circles/ellipses               |
+| Triangle  | Triangle      | -        | Draw triangles                      |
+| Text      | T             | `T`      | Add text boxes                      |
+| Image     | Image         | -        | Upload images                       |
+| Eraser    | Eraser        | `E`      | Delete objects by dragging          |
+
+---
+
+## Select Tool
+
+**Purpose**: Select, move, resize, and rotate objects on the canvas.
+
+### Behavior
+
+- **Single click** on object: Select it and show control points
+- **Click and drag**: Move the selected object
+- **Click on empty space**: Deselect current selection
+- **Drag selection box**: Select multiple objects
+- **Shift+click**: Add to selection
+
+### Control Points
+
+When an object is selected, custom control points appear:
+
+- **Corner handles (0-3)**: Resize from corners
+- **Edge handles (8-11)**: Resize from edges
+- **Rotation handle (12)**: Rotate the object (floating above top edge)
+
+### State Changes
+
+```typescript
+canvas.isDrawingMode = false;
+canvas.selection = true;
+canvas.defaultCursor = 'default';
+canvas.hoverCursor = 'move';
+```
+
+---
+
+## Pan Tool
+
+**Purpose**: Navigate around the canvas by dragging.
+
+### Behavior
+
+- **Click and drag**: Pan the canvas viewport
+- Cursor changes to "grab" (open hand) and "grabbing" (closed hand) when dragging
+- All objects become non-selectable during pan mode
+
+### Implementation
+
+Uses viewport transform manipulation:
+
+```typescript
+const vpt = canvas.viewportTransform;
+vpt[4] += e.clientX - lastPosX; // Translate X
+vpt[5] += e.clientY - lastPosY; // Translate Y
+```
+
+### State Changes
+
+```typescript
+canvas.isDrawingMode = false;
+canvas.selection = false;
+canvas.defaultCursor = 'grab';
+canvas.hoverCursor = 'grab';
+```
+
+---
+
+## Draw Tool
+
+**Purpose**: Freehand drawing with configurable brush.
+
+### Behavior
+
+- **Click and drag**: Draw on canvas
+- Creates `fabric.Path` objects when drawing completes
+- Brush type, size, and color are configurable
+
+### Brush Types
+
+| Type   | Class         | Description             |
+| ------ | ------------- | ----------------------- |
+| Pencil | `PencilBrush` | Smooth continuous line  |
+| Circle | `CircleBrush` | Dotted circular pattern |
+| Spray  | `SprayBrush`  | Spray paint effect      |
+
+### Configuration (Floating Menu)
+
+- **Brush Type**: pencil, circle, spray
+- **Brush Size**: Width in pixels
+- **Color**: Hex color picker
+- **Opacity**: 0-100%
+
+### State Changes
+
+```typescript
+canvas.isDrawingMode = true;
+canvas.selection = false;
+canvas.defaultCursor = 'crosshair';
+```
+
+---
+
+## Line Tool
+
+**Purpose**: Draw straight lines/polylines.
+
+### Behavior
+
+- **Click**: Set start point
+- **Drag**: Preview line
+- **Release**: Create line object
+
+### Line Properties
+
+- Creates `fabric.Polyline` with 2 points
+- Control points appear at both endpoints for adjustment
+- Supports stroke width, color, dash pattern, and opacity
+
+### Configuration (Floating Menu)
+
+- **Stroke Width**: Line thickness
+- **Stroke Color**: Line color
+- **Dash Pattern**: Solid or dashed
+- **Opacity**: 0-100%
+
+### State Changes
+
+```typescript
+canvas.isDrawingMode = false;
+canvas.selection = false;
+canvas.defaultCursor = 'crosshair';
+canvas.hoverCursor = 'crosshair';
+```
+
+---
+
+## Shape Tools (Rectangle, Circle, Triangle)
+
+**Purpose**: Draw geometric shapes.
+
+### Behavior
+
+- **Click**: Set starting corner
+- **Drag**: Preview shape size
+- **Release**: Create shape object
+
+### Shape Types
+
+| Shape     | Fabric Class      | Notes                |
+| --------- | ----------------- | -------------------- |
+| Rectangle | `fabric.Rect`     | Uses center origin   |
+| Circle    | `fabric.Ellipse`  | Ellipse with rx/ry   |
+| Triangle  | `fabric.Triangle` | Equilateral triangle |
+
+### Configuration (Floating Menu)
+
+- **Fill Color**: Interior color
+- **Stroke Color**: Border color
+- **Stroke Width**: Border thickness
+- **Dash Pattern**: Solid or dashed border
+- **Opacity**: 0-100%
+
+### State Changes
+
+```typescript
+canvas.isDrawingMode = false;
+canvas.selection = false;
+canvas.defaultCursor = 'crosshair';
+canvas.hoverCursor = 'crosshair';
+```
+
+---
+
+## Text Tool
+
+**Purpose**: Add editable text boxes.
+
+### Behavior
+
+- **Click**: Set text position and create textbox
+- **Double-click on existing text**: Enter edit mode
+- Creates `fabric.Textbox` objects with text wrapping
+
+### Text Features
+
+- Auto-expanding width while typing
+- Text wrapping within defined width
+- Rich text not supported (single style per textbox)
+
+### Configuration (Floating Menu)
+
+- **Font Size**: Size in pixels
+- **Font Family**: Arial, Times New Roman, etc.
+- **Font Weight**: Normal, Bold
+- **Color**: Text color
+- **Text Align**: Left, Center, Right
+- **Opacity**: 0-100%
+
+### State Changes
+
+```typescript
+canvas.isDrawingMode = false;
+canvas.selection = false;
+canvas.defaultCursor = 'crosshair';
+canvas.hoverCursor = 'crosshair';
+```
+
+---
+
+## Image Tool
+
+**Purpose**: Upload and add images to the canvas.
+
+### Behavior
+
+1. Click toolbar button → Opens file picker
+2. Select image file
+3. Image placed at canvas center
+4. Select image to show crop option
+
+### Supported Formats
+
+- JPEG, PNG, GIF, WebP, SVG
+
+### Image Features
+
+- Maintains aspect ratio when resizing from corners
+- Supports cropping via crop tool
+- Uses center origin for positioning
+
+### Cropping
+
+When an image is selected:
+
+1. Click "Crop" button in floating menu
+2. Drag crop handles to define area
+3. Click "Apply" to crop or "Cancel" to abort
+
+---
+
+## Eraser Tool
+
+**Purpose**: Delete objects by dragging over them.
+
+### Behavior
+
+- **Click and drag**: Objects under cursor are highlighted and marked for deletion
+- **Release**: All marked objects are deleted
+- Shows visual trail while dragging
+
+### Visual Feedback
+
+- Eraser trail follows cursor
+- Hovered objects dim (reduced opacity) to preview deletion
+- Objects restored if cursor moves away before release
+
+### Implementation
+
+Tracks objects in `hoveredObjectsForDeletion` array with original opacities stored for restoration.
+
+### State Changes
+
+```typescript
+canvas.isDrawingMode = false;
+canvas.selection = false;
+canvas.defaultCursor = 'crosshair';
+```
+
+---
+
+## Tool State Management
+
+### ToolState Interface
+
+```typescript
+interface ToolState {
+	selectedTool: WhiteboardTool;
+	showFloatingMenu: boolean;
+	isDrawingShape: boolean;
+	isDrawingText: boolean;
+	currentShapeType: string;
+	eraserTrail: fabric.Object[];
+	lastEraserPoint: { x: number; y: number } | null;
+	hoveredObjectsForDeletion: fabric.Object[];
+	originalOpacities: Map<fabric.Object, number>;
+	tempShape: fabric.Object | null;
+	tempText: fabric.Textbox | null;
+}
+```
+
+### Tool Switching
+
+When switching tools, cleanup functions are called:
+
+1. `clearEraserState()` - Remove eraser trail, restore opacities
+2. `clearShapeDrawingState()` - Remove temp shape preview
+3. `clearTextDrawingState()` - Remove temp text preview
+
+---
+
+## Floating Menu
+
+The floating menu appears for tools that have configurable options:
+
+| Tool   | Floating Menu Shows                      |
+| ------ | ---------------------------------------- |
+| Draw   | Brush options                            |
+| Line   | Stroke options                           |
+| Shapes | Fill + stroke options                    |
+| Text   | Font options                             |
+| Image  | Crop button (when image selected)        |
+| Eraser | Eraser size                              |
+| Select | Object properties (when object selected) |
+
+---
+
+## Source Files
+
+- **Tool Functions**: `src/lib/components/whiteboard/tools.ts`
+- **Toolbar UI**: `src/lib/components/whiteboard/whiteboard-toolbar.svelte`
+- **Floating Menu**: `src/lib/components/whiteboard/whiteboard-floating-menu.svelte`

--- a/src/lib/components/whiteboard/canvas-history.ts
+++ b/src/lib/components/whiteboard/canvas-history.ts
@@ -1,0 +1,514 @@
+import type { Canvas, FabricObject } from 'fabric';
+import type { ControlPointManager } from './control-points';
+
+/**
+ * Command interface for the Command Pattern
+ * Each command represents an undoable/redoable action
+ */
+export interface Command {
+	type: 'add' | 'modify' | 'delete' | 'batch-delete' | 'layer';
+	objectId: string;
+	userId: string;
+	timestamp: number;
+	// For add: the object data to add
+	// For delete: the object data that was deleted (needed to restore)
+	objectData: Record<string, unknown>;
+	// For modify: the state before the modification (needed to undo)
+	beforeState?: Record<string, unknown>;
+	// For modify: the state after the modification (needed to redo)
+	afterState?: Record<string, unknown>;
+	// For batch-delete: array of objects that were deleted together
+	batchObjects?: Array<{ id: string; data: Record<string, unknown> }>;
+	// For layer: the previous and new z-index
+	previousIndex?: number;
+	newIndex?: number;
+}
+
+/**
+ * History manager using Command Pattern for tracking user actions on the canvas
+ * Supports undo/redo operations for collaborative whiteboards
+ * Each user maintains their own undo/redo history
+ */
+export class CanvasHistory {
+	private undoStack: Command[] = [];
+	private redoStack: Command[] = [];
+	private maxHistorySize = 50;
+	private currentUserId: string = '';
+
+	/**
+	 * Set the current user ID for filtering history operations
+	 */
+	setCurrentUserId(userId: string) {
+		this.currentUserId = userId;
+	}
+
+	/**
+	 * Get the current user ID
+	 */
+	getCurrentUserId(): string {
+		return this.currentUserId;
+	}
+
+	/**
+	 * Push a command to the undo stack
+	 */
+	private pushCommand(command: Command) {
+		this.undoStack.push(command);
+
+		// Clear redo stack when a new action is performed by this user
+		if (command.userId === this.currentUserId) {
+			this.redoStack = this.redoStack.filter(
+				(c) => c.userId !== this.currentUserId,
+			);
+		}
+
+		// Limit stack size
+		if (this.undoStack.length > this.maxHistorySize) {
+			this.undoStack.shift();
+		}
+	}
+
+	/**
+	 * Record an add command (object was created)
+	 */
+	recordAdd(
+		objectId: string,
+		objectData: Record<string, unknown>,
+		userId: string,
+	) {
+		this.pushCommand({
+			type: 'add',
+			objectId,
+			objectData,
+			timestamp: Date.now(),
+			userId,
+		});
+	}
+
+	/**
+	 * Record a modify command (object was changed)
+	 */
+	recordModify(
+		objectId: string,
+		beforeState: Record<string, unknown>,
+		afterState: Record<string, unknown>,
+		userId: string,
+	) {
+		this.pushCommand({
+			type: 'modify',
+			objectId,
+			objectData: afterState, // Store current state as objectData for consistency
+			beforeState,
+			afterState,
+			timestamp: Date.now(),
+			userId,
+		});
+	}
+
+	/**
+	 * Record a delete command (object was removed)
+	 */
+	recordDelete(
+		objectId: string,
+		objectData: Record<string, unknown>,
+		userId: string,
+	) {
+		this.pushCommand({
+			type: 'delete',
+			objectId,
+			objectData,
+			timestamp: Date.now(),
+			userId,
+		});
+	}
+
+	/**
+	 * Record a batch delete command (multiple objects were removed together, e.g., eraser or clear all)
+	 */
+	recordBatchDelete(
+		objects: Array<{ id: string; data: Record<string, unknown> }>,
+		userId: string,
+	) {
+		if (objects.length === 0) return;
+		this.pushCommand({
+			type: 'batch-delete',
+			objectId: 'batch-' + Date.now(), // Unique ID for the batch
+			objectData: {}, // Not used for batch
+			batchObjects: objects,
+			timestamp: Date.now(),
+			userId,
+		});
+	}
+
+	/**
+	 * Record a layer change command (object z-index was changed)
+	 */
+	recordLayer(
+		objectId: string,
+		previousIndex: number,
+		newIndex: number,
+		userId: string,
+	) {
+		this.pushCommand({
+			type: 'layer',
+			objectId,
+			objectData: {}, // Not used for layer
+			previousIndex,
+			newIndex,
+			timestamp: Date.now(),
+			userId,
+		});
+	}
+
+	/**
+	 * Undo the last action by the current user
+	 * Returns the command that was undone, or null if no command to undo
+	 */
+	undo(): Command | null {
+		// Find the last command by the current user
+		const userCommands = this.undoStack
+			.map((command, index) => ({ command, index }))
+			.filter(({ command }) => command.userId === this.currentUserId);
+
+		if (userCommands.length === 0) return null;
+
+		const { command, index } = userCommands[userCommands.length - 1];
+
+		// Remove from undo stack
+		this.undoStack.splice(index, 1);
+
+		// Move to redo stack
+		this.redoStack.push(command);
+
+		return command;
+	}
+
+	/**
+	 * Redo the last undone action by the current user
+	 * Returns the command that was redone, or null if no command to redo
+	 */
+	redo(): Command | null {
+		// Find the last undone command by the current user
+		const userCommands = this.redoStack
+			.map((command, index) => ({ command, index }))
+			.filter(({ command }) => command.userId === this.currentUserId);
+
+		if (userCommands.length === 0) return null;
+
+		const { command, index } = userCommands[userCommands.length - 1];
+
+		// Remove from redo stack
+		this.redoStack.splice(index, 1);
+
+		// Move back to undo stack
+		this.undoStack.push(command);
+
+		return command;
+	}
+
+	/**
+	 * Check if undo is available for the current user
+	 */
+	canUndo(): boolean {
+		return this.undoStack.some(
+			(command) => command.userId === this.currentUserId,
+		);
+	}
+
+	/**
+	 * Check if redo is available for the current user
+	 */
+	canRedo(): boolean {
+		return this.redoStack.some(
+			(command) => command.userId === this.currentUserId,
+		);
+	}
+
+	/**
+	 * Clear all history
+	 */
+	clear() {
+		this.undoStack = [];
+		this.redoStack = [];
+	}
+
+	/**
+	 * Get the undo stack (for debugging)
+	 */
+	getUndoStack(): Command[] {
+		return [...this.undoStack];
+	}
+
+	/**
+	 * Get the redo stack (for debugging)
+	 */
+	getRedoStack(): Command[] {
+		return [...this.redoStack];
+	}
+}
+
+/**
+ * Apply an undo command to the canvas
+ * This function directly manipulates the canvas without triggering fabric.js events
+ * that would cause recursive history recording
+ */
+export async function applyUndo(
+	canvas: Canvas,
+	command: Command,
+	sendCanvasUpdate: (data: Record<string, unknown>) => void,
+	controlPointManager?: ControlPointManager,
+): Promise<void> {
+	if (command.type === 'add') {
+		// Undo an add = delete the object
+		const objects = canvas.getObjects();
+		// @ts-expect-error - custom id property
+		const obj = objects.find((o) => o.id === command.objectId);
+		if (obj) {
+			// Remove control points for this object
+			controlPointManager?.removeControlPoints(command.objectId);
+			canvas.remove(obj);
+			canvas.renderAll();
+
+			sendCanvasUpdate({ type: 'delete', objects: [{ id: command.objectId }] });
+		}
+	} else if (command.type === 'delete') {
+		// Undo a delete = restore the object
+		if (command.objectData) {
+			await restoreObjectFromData(
+				canvas,
+				command.objectData,
+				sendCanvasUpdate,
+				controlPointManager,
+			);
+		}
+	} else if (command.type === 'modify') {
+		// Undo a modify = restore the before state
+		if (command.beforeState) {
+			const objects = canvas.getObjects();
+			// @ts-expect-error - custom id property
+			const obj = objects.find((o) => o.id === command.objectId);
+			if (obj) {
+				// Apply the before state
+				obj.set(command.beforeState as Partial<FabricObject>);
+				obj.setCoords();
+
+				// Update control points if they exist
+				controlPointManager?.updateControlPoints(command.objectId, obj);
+
+				canvas.renderAll();
+
+				// Send update to other users
+				const objData = obj.toObject();
+				// @ts-expect-error - custom id property
+				objData.id = obj.id;
+				sendCanvasUpdate({ type: 'modify', object: objData });
+			}
+		}
+	} else if (command.type === 'batch-delete') {
+		// Undo a batch delete = restore all objects
+		if (command.batchObjects && command.batchObjects.length > 0) {
+			for (const objInfo of command.batchObjects) {
+				await restoreObjectFromData(
+					canvas,
+					objInfo.data,
+					sendCanvasUpdate,
+					controlPointManager,
+				);
+			}
+		}
+	} else if (command.type === 'layer') {
+		// Undo a layer change = move object back to previous position
+		if (command.previousIndex !== undefined) {
+			const objects = canvas.getObjects();
+			// @ts-expect-error - custom id property
+			const obj = objects.find((o) => o.id === command.objectId);
+			if (obj) {
+				// Move object to previous z-index using remove and insertAt
+				const currentIndex = objects.indexOf(obj);
+				if (currentIndex !== command.previousIndex) {
+					canvas.remove(obj);
+					canvas.insertAt(command.previousIndex, obj);
+				}
+				// Ensure control points stay on top
+				controlPointManager?.bringAllControlPointsToFront();
+				canvas.renderAll();
+
+				// Send layer update to other users
+				const objData = obj.toObject();
+				// @ts-expect-error - custom id property
+				objData.id = obj.id;
+				sendCanvasUpdate({
+					type: 'layer',
+					action: 'moveTo',
+					object: objData,
+					index: command.previousIndex,
+				});
+			}
+		}
+	}
+}
+
+/**
+ * Apply a redo command to the canvas
+ * This function directly manipulates the canvas without triggering fabric.js events
+ */
+export async function applyRedo(
+	canvas: Canvas,
+	command: Command,
+	sendCanvasUpdate: (data: Record<string, unknown>) => void,
+	controlPointManager?: ControlPointManager,
+): Promise<void> {
+	if (command.type === 'add') {
+		// Redo an add = restore the object
+		if (command.objectData) {
+			await restoreObjectFromData(
+				canvas,
+				command.objectData,
+				sendCanvasUpdate,
+				controlPointManager,
+			);
+		}
+	} else if (command.type === 'delete') {
+		// Redo a delete = delete the object again
+		const objects = canvas.getObjects();
+		// @ts-expect-error - custom id property
+		const obj = objects.find((o) => o.id === command.objectId);
+		if (obj) {
+			// Remove control points for this object
+			controlPointManager?.removeControlPoints(command.objectId);
+			canvas.remove(obj);
+			canvas.renderAll();
+
+			sendCanvasUpdate({ type: 'delete', objects: [{ id: command.objectId }] });
+		}
+	} else if (command.type === 'modify') {
+		// Redo a modify = apply the after state
+		if (command.afterState) {
+			const objects = canvas.getObjects();
+			// @ts-expect-error - custom id property
+			const obj = objects.find((o) => o.id === command.objectId);
+			if (obj) {
+				obj.set(command.afterState as Partial<FabricObject>);
+				obj.setCoords();
+
+				// Update control points if they exist
+				controlPointManager?.updateControlPoints(command.objectId, obj);
+
+				canvas.renderAll();
+
+				// Send update to other users
+				const objData = obj.toObject();
+				// @ts-expect-error - custom id property
+				objData.id = obj.id;
+				sendCanvasUpdate({ type: 'modify', object: objData });
+			}
+		}
+	} else if (command.type === 'batch-delete') {
+		// Redo a batch delete = delete all objects again
+		if (command.batchObjects && command.batchObjects.length > 0) {
+			const objects = canvas.getObjects();
+			const deletedIds: string[] = [];
+			for (const objInfo of command.batchObjects) {
+				// @ts-expect-error - custom id property
+				const obj = objects.find((o) => o.id === objInfo.id);
+				if (obj) {
+					// Remove control points for this object
+					controlPointManager?.removeControlPoints(objInfo.id);
+					canvas.remove(obj);
+					deletedIds.push(objInfo.id);
+				}
+			}
+			canvas.renderAll();
+
+			if (deletedIds.length > 0) {
+				sendCanvasUpdate({
+					type: 'delete',
+					objects: deletedIds.map((id) => ({ id })),
+				});
+			}
+		}
+	} else if (command.type === 'layer') {
+		// Redo a layer change = move object to new position
+		if (command.newIndex !== undefined) {
+			const objects = canvas.getObjects();
+			// @ts-expect-error - custom id property
+			const obj = objects.find((o) => o.id === command.objectId);
+			if (obj) {
+				// Move object to new z-index using remove and insertAt
+				const currentIndex = objects.indexOf(obj);
+				if (currentIndex !== command.newIndex) {
+					canvas.remove(obj);
+					canvas.insertAt(command.newIndex, obj);
+				}
+				// Ensure control points stay on top
+				controlPointManager?.bringAllControlPointsToFront();
+				canvas.renderAll();
+
+				// Send layer update to other users
+				const objData = obj.toObject();
+				// @ts-expect-error - custom id property
+				objData.id = obj.id;
+				sendCanvasUpdate({
+					type: 'layer',
+					action: 'moveTo',
+					object: objData,
+					index: command.newIndex,
+				});
+			}
+		}
+	}
+}
+
+/**
+ * Restore an object from serialized data
+ */
+async function restoreObjectFromData(
+	canvas: Canvas,
+	objectData: Record<string, unknown>,
+	sendCanvasUpdate: (data: Record<string, unknown>) => void,
+	controlPointManager?: ControlPointManager,
+): Promise<void> {
+	// Use Fabric's enlivenObjects to recreate the object
+	const { util } = await import('fabric');
+	const objects = await util.enlivenObjects([objectData]);
+
+	if (objects && objects.length > 0) {
+		const obj = objects[0];
+		if (obj && typeof obj === 'object' && 'id' in obj) {
+			// @ts-expect-error - custom id property
+			obj.id = objectData.id;
+			// Disable default fabric.js controls and borders - we use custom control points
+			// @ts-expect-error - Type assertion needed for enliven result
+			obj.set({ hasControls: false, hasBorders: false });
+			// Ensure images use center origin
+			// @ts-expect-error - Type assertion needed for enliven result
+			if (obj.type === 'image') {
+				// @ts-expect-error - Type assertion needed for enliven result
+				obj.set({ originX: 'center', originY: 'center' });
+			}
+			// @ts-expect-error - Type assertion needed for enliven result
+			canvas.add(obj);
+
+			// If this object is selected, add control points
+			const activeObject = canvas.getActiveObject();
+			if (
+				activeObject &&
+				(activeObject as any).id === objectData.id &&
+				controlPointManager
+			) {
+				controlPointManager.addControlPoints(
+					objectData.id as string,
+					obj as any,
+					true,
+				);
+			}
+
+			canvas.renderAll();
+
+			sendCanvasUpdate({ type: 'add', object: objectData });
+		}
+	}
+}
+
+// Legacy type alias for backwards compatibility
+export type HistoryAction = Command;

--- a/src/lib/components/whiteboard/control-points.ts
+++ b/src/lib/components/whiteboard/control-points.ts
@@ -1,0 +1,5026 @@
+import * as fabric from 'fabric';
+
+/**
+ * Interface for a control point visual element
+ */
+export interface ControlPoint {
+	id: string;
+	circle: fabric.Circle;
+	objectId: string;
+	pointIndex: number;
+}
+
+/**
+ * Abstract base class for control point handlers
+ * Each object type (line, rectangle, etc.) will extend this
+ */
+export abstract class ControlPointHandler {
+	protected canvas: fabric.Canvas;
+	protected controlPoints: ControlPoint[] = [];
+
+	constructor(canvas: fabric.Canvas) {
+		this.canvas = canvas;
+	}
+
+	/**
+	 * Update the visual size of control points based on zoom level
+	 */
+	updateControlPointSizes(): void {
+		const zoom = this.canvas.getZoom();
+		const scale = 1 / zoom; // Inverse scale to maintain constant visual size
+
+		this.controlPoints.forEach((cp) => {
+			cp.circle.set({ radius: 6 * scale, strokeWidth: 2 * scale });
+			cp.circle.setCoords();
+		});
+	}
+
+	/**
+	 * Add control points for an object
+	 */
+	abstract addControlPoints(
+		objectId: string,
+		obj: fabric.Object,
+		visible?: boolean,
+	): void;
+
+	/**
+	 * Remove control points for an object
+	 */
+	removeControlPoints(objectId: string): void {
+		const pointsToRemove = this.controlPoints.filter(
+			(cp) => cp.objectId === objectId,
+		);
+		pointsToRemove.forEach((cp) => {
+			this.canvas.remove(cp.circle);
+		});
+		this.controlPoints = this.controlPoints.filter(
+			(cp) => cp.objectId !== objectId,
+		);
+		this.canvas.renderAll();
+	}
+
+	/**
+	 * Hide control points for an object
+	 */
+	hideControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => {
+			cp.circle.set({ visible: false });
+		});
+		this.canvas.renderAll();
+	}
+
+	/**
+	 * Show control points for an object
+	 */
+	showControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => {
+			cp.circle.set({ visible: true });
+		});
+		this.canvas.renderAll();
+	}
+
+	/**
+	 * Hide all control points
+	 */
+	hideAllControlPoints(): void {
+		this.controlPoints.forEach((cp) => {
+			cp.circle.set({ visible: false });
+		});
+		this.canvas.renderAll();
+	}
+
+	/**
+	 * Update control point positions when object is moved/transformed
+	 */
+	abstract updateControlPoints(objectId: string, obj: fabric.Object): void;
+
+	/**
+	 * Update the object when a control point is dragged
+	 */
+	abstract updateObjectFromControlPoint(
+		controlPointId: string,
+		newX: number,
+		newY: number,
+	): void;
+
+	/**
+	 * Get all control points for a specific object
+	 */
+	getControlPointsForObject(objectId: string): ControlPoint[] {
+		return this.controlPoints.filter((cp) => cp.objectId === objectId);
+	}
+
+	/**
+	 * Get all control points
+	 */
+	getAllControlPoints(): ControlPoint[] {
+		return this.controlPoints;
+	}
+
+	/**
+	 * Check if a circle is a control point
+	 */
+	isControlPoint(obj: fabric.Object): boolean {
+		return (obj as any).isControlPoint === true;
+	}
+
+	/**
+	 * Bring all control points to the front of the canvas
+	 */
+	bringControlPointsToFront(): void {
+		this.controlPoints.forEach((cp) => {
+			this.canvas.bringObjectToFront(cp.circle);
+		});
+	}
+
+	/**
+	 * Create a visual control point circle
+	 */
+	protected createControlPointCircle(
+		x: number,
+		y: number,
+		controlPointId: string,
+		objectId: string,
+		pointIndex: number,
+		selectable: boolean = true,
+	): fabric.Circle {
+		// Get current zoom to size control points correctly from the start
+		const zoom = this.canvas.getZoom();
+		const scale = 1 / zoom;
+
+		const circle = new fabric.Circle({
+			radius: 6 * scale,
+			fill: 'oklch(0.6171 0.1375 39.0427)',
+			stroke: 'oklch(0.5171 0.1375 39.0427)',
+			strokeWidth: 2 * scale,
+			left: x,
+			top: y,
+			originX: 'center',
+			originY: 'center',
+			selectable: selectable,
+			hasControls: false,
+			hasBorders: false,
+			hoverCursor: 'move',
+			evented: true,
+			excludeFromExport: true, // Exclude from canvas serialization
+		});
+
+		// Add custom properties to identify this as a control point
+		(circle as any).id = controlPointId;
+		(circle as any).isControlPoint = true;
+		(circle as any).linkedObjectId = objectId;
+		(circle as any).pointIndex = pointIndex;
+
+		return circle;
+	}
+}
+
+/**
+ * Control point handler for polylines (lines and arrows)
+ */
+export class LineControlPoints extends ControlPointHandler {
+	addControlPoints(
+		objectId: string,
+		obj: fabric.Object,
+		visible: boolean = true,
+	): void {
+		const line = obj as fabric.Polyline;
+		const points = line.points;
+		if (!points || points.length < 2) return;
+
+		// Get the line's transformation matrix to calculate absolute positions
+		const matrix = line.calcTransformMatrix();
+
+		// Create control points at start and end of line
+		[0, points.length - 1].forEach((pointIndex) => {
+			const point = points[pointIndex];
+			// Transform the point to absolute coordinates
+			const absolutePoint = fabric.util.transformPoint(
+				new fabric.Point(
+					point.x - line.pathOffset.x,
+					point.y - line.pathOffset.y,
+				),
+				matrix,
+			);
+
+			const controlPointId = `${objectId}-cp-${pointIndex}`;
+			const circle = this.createControlPointCircle(
+				absolutePoint.x,
+				absolutePoint.y,
+				controlPointId,
+				objectId,
+				pointIndex,
+			);
+
+			// Set initial visibility
+			circle.set({ visible });
+
+			this.canvas.add(circle);
+
+			// Store the control point reference
+			this.controlPoints.push({
+				id: controlPointId,
+				circle,
+				objectId,
+				pointIndex,
+			});
+		});
+
+		// Ensure all control points are on top
+		this.bringControlPointsToFront();
+		this.canvas.renderAll();
+	}
+
+	updateControlPoints(objectId: string, obj: fabric.Object): void {
+		const line = obj as fabric.Polyline;
+		const controlPoints = this.getControlPointsForObject(objectId);
+		if (controlPoints.length === 0) return;
+
+		const points = line.points;
+		if (!points || points.length < 2) return;
+
+		// Get the line's transformation matrix to calculate absolute positions
+		const matrix = line.calcTransformMatrix();
+
+		// Update each control point position
+		controlPoints.forEach((cp) => {
+			const point = points[cp.pointIndex];
+			const absolutePoint = fabric.util.transformPoint(
+				new fabric.Point(
+					point.x - line.pathOffset.x,
+					point.y - line.pathOffset.y,
+				),
+				matrix,
+			);
+			cp.circle.set({ left: absolutePoint.x, top: absolutePoint.y });
+			cp.circle.setCoords();
+		});
+
+		this.canvas.renderAll();
+	}
+
+	updateObjectFromControlPoint(
+		controlPointId: string,
+		newX: number,
+		newY: number,
+	): void {
+		// Find the control point
+		const controlPoint = this.controlPoints.find(
+			(cp) => cp.id === controlPointId,
+		);
+		if (!controlPoint) return;
+
+		// Update the control point circle position immediately
+		controlPoint.circle.set({ left: newX, top: newY });
+		controlPoint.circle.setCoords();
+
+		// Find the line on the canvas
+		const line = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) =>
+					obj.id === controlPoint.objectId && obj.type === 'polyline',
+			) as fabric.Polyline | undefined;
+		if (!line || !line.points) return;
+
+		// Get the line's current transformation matrix
+		const matrix = line.calcTransformMatrix();
+
+		// Convert all current points to absolute coordinates
+		const absolutePoints = line.points.map((point) => {
+			return fabric.util.transformPoint(
+				new fabric.Point(
+					point.x - line.pathOffset.x,
+					point.y - line.pathOffset.y,
+				),
+				matrix,
+			);
+		});
+
+		// Update the dragged point to the new position
+		absolutePoints[controlPoint.pointIndex] = new fabric.Point(newX, newY);
+
+		// Store line properties before removal
+		const lineId = (line as any).id;
+		const lineProps = {
+			stroke: line.stroke,
+			strokeWidth: line.strokeWidth,
+			strokeDashArray: line.strokeDashArray,
+			opacity: line.opacity,
+		};
+
+		// Remove old line
+		this.canvas.remove(line);
+
+		// Create new line with absolute points (no transformations)
+		const newLine = new fabric.Polyline(absolutePoints, {
+			id: lineId,
+			stroke: lineProps.stroke,
+			strokeWidth: lineProps.strokeWidth,
+			strokeDashArray: lineProps.strokeDashArray,
+			opacity: lineProps.opacity,
+			selectable: true,
+			hasControls: false,
+			hasBorders: false,
+			strokeUniform: true,
+		});
+
+		this.canvas.add(newLine);
+
+		// Bring control points to front
+		this.bringControlPointsToFront();
+
+		// Update other control point positions
+		const otherControlPoints = this.controlPoints.filter(
+			(cp) => cp.objectId === controlPoint.objectId && cp.id !== controlPointId,
+		);
+
+		const newMatrix = newLine.calcTransformMatrix();
+		otherControlPoints.forEach((cp) => {
+			const point = absolutePoints[cp.pointIndex];
+			cp.circle.set({ left: point.x, top: point.y });
+			cp.circle.setCoords();
+		});
+
+		this.canvas.renderAll();
+	}
+
+	/**
+	 * Get the updated line object after a control point was moved
+	 * Returns the new line object so it can be sent to other users
+	 */
+	getUpdatedLine(controlPointId: string): fabric.Polyline | null {
+		const controlPoint = this.controlPoints.find(
+			(cp) => cp.id === controlPointId,
+		);
+		if (!controlPoint) return null;
+
+		const line = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) =>
+					obj.id === controlPoint.objectId && obj.type === 'polyline',
+			) as fabric.Polyline | undefined;
+
+		return line || null;
+	}
+}
+
+/**
+ * Abstract base class for bounding box control points
+ * Provides standard 4 corners + 4 edges + 1 rotation + border lines
+ */
+export abstract class BoundingBoxControlPoints extends ControlPointHandler {
+	protected edgeLines: Map<string, fabric.Line> = new Map();
+
+	/**
+	 * Get the zoom-adjusted distance for the rotation handle
+	 */
+	protected getRotationHandleDistance(): number {
+		const zoom = this.canvas.getZoom();
+		return 20 / zoom; // Scale inversely with zoom to maintain constant visual distance
+	}
+
+	/**
+	 * Override to also bring edge lines to front
+	 */
+	bringControlPointsToFront(): void {
+		// First bring edge lines to front
+		this.edgeLines.forEach((line) => {
+			this.canvas.bringObjectToFront(line);
+		});
+		// Then bring control point circles to front (so they're on top of the lines)
+		this.controlPoints.forEach((cp) => {
+			this.canvas.bringObjectToFront(cp.circle);
+		});
+	}
+
+	/**
+	 * Override to also update edge line sizes and rotation handle position
+	 */
+	updateControlPointSizes(): void {
+		const zoom = this.canvas.getZoom();
+		const scale = 1 / zoom;
+
+		// Update control point circles
+		this.controlPoints.forEach((cp) => {
+			cp.circle.set({ radius: 6 * scale, strokeWidth: 2 * scale });
+			cp.circle.setCoords();
+		});
+
+		// Update edge lines
+		this.edgeLines.forEach((line) => {
+			line.set({ strokeWidth: 1.5 * scale });
+			line.setCoords();
+		});
+
+		// Update rotation handle positions (index 12) for all objects with rotation handles
+		const objectsWithRotation = new Set<string>();
+		this.controlPoints.forEach((cp) => {
+			if (cp.pointIndex === 12) {
+				objectsWithRotation.add(cp.objectId);
+			}
+		});
+
+		objectsWithRotation.forEach((objectId) => {
+			// Find the object
+			const obj = this.canvas.getObjects().find((o: any) => o.id === objectId);
+			if (obj) {
+				// Update just the rotation handle position
+				const rotationCp = this.controlPoints.find(
+					(cp) => cp.objectId === objectId && cp.pointIndex === 12,
+				);
+				const topMidpointCp = this.controlPoints.find(
+					(cp) => cp.objectId === objectId && cp.pointIndex === 8,
+				);
+
+				if (rotationCp && topMidpointCp) {
+					const center = obj.getCenterPoint();
+					const topMidpoint = topMidpointCp.circle.getCenterPoint();
+					const vectorX = topMidpoint.x - center.x;
+					const vectorY = topMidpoint.y - center.y;
+					const vectorLength = Math.sqrt(vectorX * vectorX + vectorY * vectorY);
+					const normalizedX = vectorX / vectorLength;
+					const normalizedY = vectorY / vectorLength;
+					const rotationDistance = this.getRotationHandleDistance();
+
+					rotationCp.circle.set({
+						left: center.x + normalizedX * (vectorLength + rotationDistance),
+						top: center.y + normalizedY * (vectorLength + rotationDistance),
+					});
+					rotationCp.circle.setCoords();
+				}
+			}
+		});
+	}
+}
+
+/**
+ * Control point handler for rectangles
+ */
+export class RectangleControlPoints extends BoundingBoxControlPoints {
+	addControlPoints(
+		objectId: string,
+		obj: fabric.Object,
+		visible: boolean = true,
+	): void {
+		const rect = obj as fabric.Rect;
+		const left = rect.left || 0;
+		const top = rect.top || 0;
+		const width = rect.width || 0;
+		const height = rect.height || 0;
+
+		// Get transformation matrix for handling rotations/scaling
+		const matrix = rect.calcTransformMatrix();
+
+		// Define the 4 corners in local coordinates
+		// Rectangles use different origins - check originX/originY
+		const originX = rect.originX || 'left';
+		const originY = rect.originY || 'top';
+
+		let corners;
+		if (originX === 'center' && originY === 'center') {
+			// Center origin
+			corners = [
+				{ x: -width / 2, y: -height / 2 }, // Top-left
+				{ x: width / 2, y: -height / 2 }, // Top-right
+				{ x: width / 2, y: height / 2 }, // Bottom-right
+				{ x: -width / 2, y: height / 2 }, // Bottom-left
+			];
+		} else {
+			// Top-left origin (default)
+			corners = [
+				{ x: 0, y: 0 }, // Top-left
+				{ x: width, y: 0 }, // Top-right
+				{ x: width, y: height }, // Bottom-right
+				{ x: 0, y: height }, // Bottom-left
+			];
+		}
+
+		// Transform corners to absolute coordinates
+		const absoluteCorners = corners.map((corner) =>
+			fabric.util.transformPoint(new fabric.Point(corner.x, corner.y), matrix),
+		);
+
+		// Create control points at corners (selectable to allow dragging)
+		absoluteCorners.forEach((corner, index) => {
+			const controlPointId = `${objectId}-cp-${index}`;
+			const circle = this.createControlPointCircle(
+				corner.x,
+				corner.y,
+				controlPointId,
+				objectId,
+				index,
+				true, // Must be selectable for dragging
+			);
+			circle.set({ visible });
+			this.canvas.add(circle);
+			this.controlPoints.push({
+				id: controlPointId,
+				circle,
+				objectId,
+				pointIndex: index,
+			});
+		});
+
+		// Create edge midpoint control points
+		const edgeMidpoints = [
+			{
+				x: (absoluteCorners[0].x + absoluteCorners[1].x) / 2,
+				y: (absoluteCorners[0].y + absoluteCorners[1].y) / 2,
+				edgeIndex: 4, // Top edge
+				cursor: 'ns-resize',
+			},
+			{
+				x: (absoluteCorners[1].x + absoluteCorners[2].x) / 2,
+				y: (absoluteCorners[1].y + absoluteCorners[2].y) / 2,
+				edgeIndex: 5, // Right edge
+				cursor: 'ew-resize',
+			},
+			{
+				x: (absoluteCorners[2].x + absoluteCorners[3].x) / 2,
+				y: (absoluteCorners[2].y + absoluteCorners[3].y) / 2,
+				edgeIndex: 6, // Bottom edge
+				cursor: 'ns-resize',
+			},
+			{
+				x: (absoluteCorners[3].x + absoluteCorners[0].x) / 2,
+				y: (absoluteCorners[3].y + absoluteCorners[0].y) / 2,
+				edgeIndex: 7, // Left edge
+				cursor: 'ew-resize',
+			},
+		];
+
+		// Add edge midpoint control points (indices 8-11, selectable for dragging)
+		edgeMidpoints.forEach((midpoint, index) => {
+			const pointIndex = 8 + index; // 8, 9, 10, 11 for top, right, bottom, left
+			const controlPointId = `${objectId}-cp-${pointIndex}`;
+			const circle = this.createControlPointCircle(
+				midpoint.x,
+				midpoint.y,
+				controlPointId,
+				objectId,
+				pointIndex,
+				true, // Must be selectable for dragging
+			);
+			circle.set({ visible, hoverCursor: midpoint.cursor });
+			// Mark this as an edge midpoint
+			(circle as any).isEdgeMidpoint = true;
+			(circle as any).edgeIndex = midpoint.edgeIndex;
+
+			this.canvas.add(circle);
+			this.controlPoints.push({
+				id: controlPointId,
+				circle,
+				objectId,
+				pointIndex,
+			});
+		});
+
+		// Create rotation handle (index 12) - floating, 30px above the top edge in rotated space
+		const topMidpoint = edgeMidpoints[0]; // Top edge midpoint
+		const center = rect.getCenterPoint();
+		const vectorX = topMidpoint.x - center.x;
+		const vectorY = topMidpoint.y - center.y;
+		const vectorLength = Math.sqrt(vectorX * vectorX + vectorY * vectorY);
+		const normalizedX = vectorX / vectorLength;
+		const normalizedY = vectorY / vectorLength;
+		const rotationDistance = this.getRotationHandleDistance();
+		const rotationX =
+			center.x + normalizedX * (vectorLength + rotationDistance);
+		const rotationY =
+			center.y + normalizedY * (vectorLength + rotationDistance);
+		const rotationControlPointId = `${objectId}-cp-12`;
+		const rotationCircle = this.createControlPointCircle(
+			rotationX,
+			rotationY,
+			rotationControlPointId,
+			objectId,
+			12,
+			true,
+		);
+		rotationCircle.set({ visible, hoverCursor: 'crosshair' });
+		this.canvas.add(rotationCircle);
+		this.controlPoints.push({
+			id: rotationControlPointId,
+			circle: rotationCircle,
+			objectId,
+			pointIndex: 12,
+		});
+
+		this.bringControlPointsToFront();
+		this.canvas.renderAll();
+	}
+
+	removeControlPoints(objectId: string): void {
+		// Remove corner control points
+		const pointsToRemove = this.controlPoints.filter(
+			(cp) => cp.objectId === objectId,
+		);
+		pointsToRemove.forEach((cp) => {
+			this.canvas.remove(cp.circle);
+		});
+		this.controlPoints = this.controlPoints.filter(
+			(cp) => cp.objectId !== objectId,
+		);
+
+		// Remove edge lines
+		const edgeLinesToRemove: string[] = [];
+		this.edgeLines.forEach((line, id) => {
+			if ((line as any).linkedObjectId === objectId) {
+				this.canvas.remove(line);
+				edgeLinesToRemove.push(id);
+			}
+		});
+		edgeLinesToRemove.forEach((id) => this.edgeLines.delete(id));
+
+		this.canvas.renderAll();
+	}
+
+	hideControlPoints(objectId: string): void {
+		// Hide corner points
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => {
+			cp.circle.set({ visible: false });
+		});
+
+		// Hide edge lines
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId) {
+				line.set({ visible: false });
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	showControlPoints(objectId: string): void {
+		// Show corner points
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => {
+			cp.circle.set({ visible: true });
+		});
+
+		// Show edge lines
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId) {
+				line.set({ visible: true });
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	updateControlPoints(objectId: string, obj: fabric.Object): void {
+		const rect = obj as fabric.Rect;
+		const controlPoints = this.getControlPointsForObject(objectId);
+		if (controlPoints.length === 0) return;
+
+		const left = rect.left || 0;
+		const top = rect.top || 0;
+		const width = rect.width || 0;
+		const height = rect.height || 0;
+
+		// Get transformation matrix
+		const matrix = rect.calcTransformMatrix();
+
+		// Define corners in local coordinates - check origin
+		const originX = rect.originX || 'left';
+		const originY = rect.originY || 'top';
+
+		let corners;
+		if (originX === 'center' && originY === 'center') {
+			// Center origin
+			corners = [
+				{ x: -width / 2, y: -height / 2 }, // Top-left
+				{ x: width / 2, y: -height / 2 }, // Top-right
+				{ x: width / 2, y: height / 2 }, // Bottom-right
+				{ x: -width / 2, y: height / 2 }, // Bottom-left
+			];
+		} else {
+			// Top-left origin (default)
+			corners = [
+				{ x: 0, y: 0 }, // Top-left
+				{ x: width, y: 0 }, // Top-right
+				{ x: width, y: height }, // Bottom-right
+				{ x: 0, y: height }, // Bottom-left
+			];
+		}
+
+		// Transform to absolute coordinates
+		const absoluteCorners = corners.map((corner) =>
+			fabric.util.transformPoint(new fabric.Point(corner.x, corner.y), matrix),
+		);
+
+		// Update corner control points (indices 0-3)
+		controlPoints.forEach((cp) => {
+			if (cp.pointIndex >= 0 && cp.pointIndex <= 3) {
+				const corner = absoluteCorners[cp.pointIndex];
+				cp.circle.set({ left: corner.x, top: corner.y });
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update edge midpoint control points (indices 8-11)
+		const edgeMidpoints = [
+			{
+				x: (absoluteCorners[0].x + absoluteCorners[1].x) / 2,
+				y: (absoluteCorners[0].y + absoluteCorners[1].y) / 2,
+				pointIndex: 8, // Top edge
+			},
+			{
+				x: (absoluteCorners[1].x + absoluteCorners[2].x) / 2,
+				y: (absoluteCorners[1].y + absoluteCorners[2].y) / 2,
+				pointIndex: 9, // Right edge
+			},
+			{
+				x: (absoluteCorners[2].x + absoluteCorners[3].x) / 2,
+				y: (absoluteCorners[2].y + absoluteCorners[3].y) / 2,
+				pointIndex: 10, // Bottom edge
+			},
+			{
+				x: (absoluteCorners[3].x + absoluteCorners[0].x) / 2,
+				y: (absoluteCorners[3].y + absoluteCorners[0].y) / 2,
+				pointIndex: 11, // Left edge
+			},
+		];
+
+		edgeMidpoints.forEach((midpoint) => {
+			const cp = controlPoints.find(
+				(cp) => cp.pointIndex === midpoint.pointIndex,
+			);
+			if (cp) {
+				cp.circle.set({ left: midpoint.x, top: midpoint.y });
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update rotation handle (index 12) - maintain 30px distance from top edge
+		const topMidpoint = edgeMidpoints[0];
+		const rotationCp = controlPoints.find((cp) => cp.pointIndex === 12);
+		if (rotationCp) {
+			// Calculate the vector from center to top midpoint (perpendicular to top edge in rotated space)
+			const center = rect.getCenterPoint();
+			const vectorX = topMidpoint.x - center.x;
+			const vectorY = topMidpoint.y - center.y;
+			const vectorLength = Math.sqrt(vectorX * vectorX + vectorY * vectorY);
+
+			// Normalize and extend by zoom-adjusted distance
+			const normalizedX = vectorX / vectorLength;
+			const normalizedY = vectorY / vectorLength;
+			const rotationDistance = this.getRotationHandleDistance();
+			const rotationX =
+				center.x + normalizedX * (vectorLength + rotationDistance);
+			const rotationY =
+				center.y + normalizedY * (vectorLength + rotationDistance);
+
+			rotationCp.circle.set({ left: rotationX, top: rotationY });
+			rotationCp.circle.setCoords();
+		}
+
+		// Update edge lines - use index 0-3, not 4-7
+		const edges = [
+			{ start: 0, end: 1 }, // Top
+			{ start: 1, end: 2 }, // Right
+			{ start: 2, end: 3 }, // Bottom
+			{ start: 3, end: 0 }, // Left
+		];
+
+		edges.forEach(({ start, end }, index) => {
+			const edgeId = `${objectId}-edge-${index}`;
+			const edgeLine = this.edgeLines.get(edgeId);
+			if (edgeLine) {
+				const startCorner = absoluteCorners[start];
+				const endCorner = absoluteCorners[end];
+				edgeLine.set({
+					x1: startCorner.x,
+					y1: startCorner.y,
+					x2: endCorner.x,
+					y2: endCorner.y,
+				});
+				edgeLine.setCoords();
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	updateObjectFromControlPoint(
+		controlPointId: string,
+		newX: number,
+		newY: number,
+	): void {
+		// Check if this is a control point (corner or edge midpoint)
+		const controlPoint = this.controlPoints.find(
+			(cp) => cp.id === controlPointId,
+		);
+
+		if (controlPoint) {
+			// Check if it's a corner control point (0-3) or edge midpoint (8-11) or rotation (12)
+			if (controlPoint.pointIndex >= 0 && controlPoint.pointIndex <= 3) {
+				// This is a corner control point
+				this.updateFromCorner(controlPoint, newX, newY);
+				return;
+			} else if (
+				controlPoint.pointIndex >= 8 &&
+				controlPoint.pointIndex <= 11
+			) {
+				// This is an edge midpoint control point
+				const edgeIndex = (controlPoint.circle as any).edgeIndex;
+				this.updateFromEdgeMidpoint(controlPoint, edgeIndex, newX, newY);
+				return;
+			} else if (controlPoint.pointIndex === 12) {
+				// Rotation handle
+				this.updateFromRotation(controlPoint, newX, newY);
+				return;
+			}
+		}
+
+		// Check if this is an edge line
+		const edgeLine = this.edgeLines.get(controlPointId);
+		if (edgeLine) {
+			const linkedObjectId = (edgeLine as any).linkedObjectId;
+			const edgeIndex = (edgeLine as any).edgeIndex;
+			this.updateFromEdge(linkedObjectId, edgeIndex, newX, newY);
+		}
+	}
+
+	private updateFromRotation(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const rect = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) => obj.id === controlPoint.objectId && obj.type === 'rect',
+			) as fabric.Rect | undefined;
+		if (!rect) return;
+
+		const center = rect.getCenterPoint();
+
+		// Calculate angle from center to rotation handle
+		const dx = newX - center.x;
+		const dy = newY - center.y;
+		const angleRad = Math.atan2(dy, dx);
+		const angleDeg = (angleRad * 180) / Math.PI + 90; // Add 90 to align with top
+
+		// Update rectangle rotation
+		rect.set({ angle: angleDeg });
+		rect.setCoords();
+
+		// Update control points
+		this.updateControlPoints(controlPoint.objectId, rect);
+		this.canvas.renderAll();
+	}
+
+	private updateFromEdgeMidpoint(
+		controlPoint: ControlPoint,
+		edgeIndex: number,
+		newX: number,
+		newY: number,
+	): void {
+		// Update the control point position immediately
+		controlPoint.circle.set({ left: newX, top: newY });
+		controlPoint.circle.setCoords();
+
+		// Call updateFromEdge with the object ID and edge index
+		this.updateFromEdge(controlPoint.objectId, edgeIndex, newX, newY);
+	}
+
+	private updateFromCorner(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		// Update the control point position immediately
+		controlPoint.circle.set({ left: newX, top: newY });
+		controlPoint.circle.setCoords();
+
+		// Find the rectangle
+		const rect = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) => obj.id === controlPoint.objectId && obj.type === 'rect',
+			) as fabric.Rect | undefined;
+		if (!rect) return;
+
+		const width = rect.width || 0;
+		const height = rect.height || 0;
+		const angle = rect.angle || 0;
+		const angleRad = (angle * Math.PI) / 180;
+
+		// Calculate the four corners in absolute coordinates
+		const matrix = rect.calcTransformMatrix();
+		const corners: fabric.Point[] = [
+			new fabric.Point(-width / 2, -height / 2), // Top-left (0)
+			new fabric.Point(width / 2, -height / 2), // Top-right (1)
+			new fabric.Point(width / 2, height / 2), // Bottom-right (2)
+			new fabric.Point(-width / 2, height / 2), // Bottom-left (3)
+		].map((corner) => fabric.util.transformPoint(corner, matrix));
+
+		// Determine which corner is the opposite/anchor corner
+		const oppositeCornerIndex = (controlPoint.pointIndex + 2) % 4;
+		const anchorCorner = corners[oppositeCornerIndex];
+
+		// Store the anchor corner's CURRENT position (we'll keep it fixed)
+		const anchorCornerCP = this.getControlPointsForObject(
+			controlPoint.objectId,
+		).find((cp) => cp.pointIndex === oppositeCornerIndex);
+		const anchorPosition = anchorCornerCP
+			? anchorCornerCP.circle.getCenterPoint()
+			: anchorCorner;
+
+		// The new dragged position
+		const draggedCorner = new fabric.Point(newX, newY);
+
+		// Vector from anchor to dragged corner
+		const vectorX = draggedCorner.x - anchorPosition.x;
+		const vectorY = draggedCorner.y - anchorPosition.y;
+
+		// Project this vector onto the rotated width and height axes
+		// Width axis (rotated horizontal)
+		const widthAxisX = Math.cos(angleRad);
+		const widthAxisY = Math.sin(angleRad);
+		const widthProjection = vectorX * widthAxisX + vectorY * widthAxisY;
+
+		// Height axis (rotated vertical)
+		const heightAxisX = -Math.sin(angleRad);
+		const heightAxisY = Math.cos(angleRad);
+		const heightProjection = vectorX * heightAxisX + vectorY * heightAxisY;
+
+		// New dimensions (absolute values, minimum 10px)
+		const newWidth = Math.max(10, Math.abs(widthProjection));
+		const newHeight = Math.max(10, Math.abs(heightProjection));
+
+		// New center is halfway between anchor and dragged corner
+		const newCenterX =
+			anchorPosition.x +
+			(widthProjection * widthAxisX) / 2 +
+			(heightProjection * heightAxisX) / 2;
+		const newCenterY =
+			anchorPosition.y +
+			(widthProjection * widthAxisY) / 2 +
+			(heightProjection * heightAxisY) / 2;
+
+		// Store rectangle properties INCLUDING ANGLE
+		const rectId = (rect as any).id;
+		const rectProps = {
+			fill: rect.fill,
+			stroke: rect.stroke,
+			strokeWidth: rect.strokeWidth,
+			strokeDashArray: rect.strokeDashArray,
+			opacity: rect.opacity,
+			angle: angle,
+		};
+
+		// Remove old rectangle
+		this.canvas.remove(rect);
+
+		// Create new rectangle
+		const newRect = new fabric.Rect({
+			id: rectId,
+			left: newCenterX,
+			top: newCenterY,
+			width: newWidth,
+			height: newHeight,
+			angle: rectProps.angle,
+			fill: rectProps.fill,
+			stroke: rectProps.stroke,
+			strokeWidth: rectProps.strokeWidth,
+			strokeDashArray: rectProps.strokeDashArray,
+			opacity: rectProps.opacity,
+			selectable: true,
+			hasControls: false,
+			hasBorders: false,
+			strokeUniform: true,
+			originX: 'center',
+			originY: 'center',
+		});
+
+		this.canvas.add(newRect);
+		this.bringControlPointsToFront();
+
+		// Update ALL control points to match new rectangle
+		this.updateControlPoints(controlPoint.objectId, newRect);
+
+		this.canvas.renderAll();
+	}
+
+	/**
+	 * Update edge lines based on actual corner positions
+	 */
+	private updateEdgeLinesFromCorners(
+		objectId: string,
+		cornerPositions: fabric.Point[],
+	): void {
+		const edges = [
+			{ start: 0, end: 1, edgeIndex: 4 }, // Top
+			{ start: 1, end: 2, edgeIndex: 5 }, // Right
+			{ start: 2, end: 3, edgeIndex: 6 }, // Bottom
+			{ start: 3, end: 0, edgeIndex: 7 }, // Left
+		];
+
+		edges.forEach(({ start, end, edgeIndex }) => {
+			const edgeId = `${objectId}-edge-${edgeIndex}`;
+			const edgeLine = this.edgeLines.get(edgeId);
+			if (edgeLine) {
+				const startCorner = cornerPositions[start];
+				const endCorner = cornerPositions[end];
+				edgeLine.set({
+					x1: startCorner.x,
+					y1: startCorner.y,
+					x2: endCorner.x,
+					y2: endCorner.y,
+				});
+				edgeLine.setCoords();
+			}
+		});
+	}
+
+	private updateFromEdge(
+		objectId: string,
+		edgeIndex: number,
+		newX: number,
+		newY: number,
+	): void {
+		// Find the rectangle
+		const rect = this.canvas
+			.getObjects()
+			.find((obj: any) => obj.id === objectId && obj.type === 'rect') as
+			| fabric.Rect
+			| undefined;
+		if (!rect) return;
+
+		const width = rect.width || 0;
+		const height = rect.height || 0;
+		const angle = rect.angle || 0;
+		const center = rect.getCenterPoint();
+
+		// Convert angle to radians
+		const angleRad = (angle * Math.PI) / 180;
+
+		const newPoint = new fabric.Point(newX, newY);
+
+		// Determine which dimension to change and how to move the center
+		let newWidth = width;
+		let newHeight = height;
+		let newCenterX = center.x;
+		let newCenterY = center.y;
+
+		switch (edgeIndex) {
+			case 4: // Top edge
+			case 6: {
+				// Bottom edge
+				// Direction perpendicular to the edge (pointing inward/outward)
+				const perpX = -Math.sin(angleRad);
+				const perpY = Math.cos(angleRad);
+				// For top edge (4), perpendicular points up (negative in local coords)
+				// For bottom edge (6), perpendicular points down (positive in local coords)
+				const edgeSign = edgeIndex === 4 ? -1 : 1;
+				// Calculate where the opposite edge currently is
+				const oppositeEdgeOffset = (height / 2) * -edgeSign;
+				const oppositeEdgeX = center.x + perpX * oppositeEdgeOffset;
+				const oppositeEdgeY = center.y + perpY * oppositeEdgeOffset;
+				// Distance from new mouse position to opposite edge (in perpendicular direction)
+				const distanceFromOpposite =
+					(newPoint.x - oppositeEdgeX) * perpX +
+					(newPoint.y - oppositeEdgeY) * perpY;
+				// New height is this distance (with correct sign)
+				newHeight = Math.max(10, Math.abs(distanceFromOpposite));
+				// New center is halfway between mouse and opposite edge
+				newCenterX = oppositeEdgeX + (perpX * distanceFromOpposite) / 2;
+				newCenterY = oppositeEdgeY + (perpY * distanceFromOpposite) / 2;
+				break;
+			}
+			case 5: // Right edge
+			case 7: {
+				// Left edge
+				// Direction perpendicular to the edge (pointing inward/outward)
+				const perpX = Math.cos(angleRad);
+				const perpY = Math.sin(angleRad);
+				// For left edge (7), perpendicular points left (negative in local coords)
+				// For right edge (5), perpendicular points right (positive in local coords)
+				const edgeSign = edgeIndex === 7 ? -1 : 1;
+				// Calculate where the opposite edge currently is
+				const oppositeEdgeOffset = (width / 2) * -edgeSign;
+				const oppositeEdgeX = center.x + perpX * oppositeEdgeOffset;
+				const oppositeEdgeY = center.y + perpY * oppositeEdgeOffset;
+				// Distance from new mouse position to opposite edge (in perpendicular direction)
+				const distanceFromOpposite =
+					(newPoint.x - oppositeEdgeX) * perpX +
+					(newPoint.y - oppositeEdgeY) * perpY;
+				// New width is this distance (with correct sign)
+				newWidth = Math.max(10, Math.abs(distanceFromOpposite));
+				// New center is halfway between mouse and opposite edge
+				newCenterX = oppositeEdgeX + (perpX * distanceFromOpposite) / 2;
+				newCenterY = oppositeEdgeY + (perpY * distanceFromOpposite) / 2;
+				break;
+			}
+		}
+
+		// Store rectangle properties INCLUDING ANGLE
+		const rectId = (rect as any).id;
+		const rectProps = {
+			fill: rect.fill,
+			stroke: rect.stroke,
+			strokeWidth: rect.strokeWidth,
+			strokeDashArray: rect.strokeDashArray,
+			opacity: rect.opacity,
+			angle: angle,
+		};
+
+		// Remove old rectangle
+		this.canvas.remove(rect);
+
+		// Create new rectangle with updated center and dimensions
+		const newRect = new fabric.Rect({
+			id: rectId,
+			left: newCenterX,
+			top: newCenterY,
+			width: newWidth,
+			height: newHeight,
+			angle: rectProps.angle,
+			fill: rectProps.fill,
+			stroke: rectProps.stroke,
+			strokeWidth: rectProps.strokeWidth,
+			strokeDashArray: rectProps.strokeDashArray,
+			opacity: rectProps.opacity,
+			selectable: true,
+			hasControls: false,
+			hasBorders: false,
+			strokeUniform: true,
+			originX: 'center',
+			originY: 'center',
+		});
+
+		this.canvas.add(newRect);
+		this.bringControlPointsToFront();
+
+		// Update all control points
+		this.updateControlPoints(objectId, newRect);
+		this.canvas.renderAll();
+	}
+}
+
+/**
+ * Control point handler for ellipses
+ */
+export class EllipseControlPoints extends BoundingBoxControlPoints {
+	addControlPoints(
+		objectId: string,
+		obj: fabric.Object,
+		visible: boolean = true,
+	): void {
+		const ellipse = obj as fabric.Ellipse;
+		const rx = ellipse.rx || 0;
+		const ry = ellipse.ry || 0;
+		const strokeWidth = ellipse.strokeWidth || 0;
+
+		// Add padding to account for stroke width - half extends outside
+		const padding = strokeWidth / 2;
+
+		// Get transformation matrix for handling rotations/scaling
+		const matrix = ellipse.calcTransformMatrix();
+
+		// Define the 4 corners of the bounding rectangle in local coordinates with padding
+		const corners = [
+			{ x: -(rx + padding), y: -(ry + padding) }, // Top-left
+			{ x: rx + padding, y: -(ry + padding) }, // Top-right
+			{ x: rx + padding, y: ry + padding }, // Bottom-right
+			{ x: -(rx + padding), y: ry + padding }, // Bottom-left
+		];
+
+		// Transform corners to absolute coordinates
+		const absoluteCorners = corners.map((corner) =>
+			fabric.util.transformPoint(new fabric.Point(corner.x, corner.y), matrix),
+		);
+
+		// Create control points at corners (indices 0-3)
+		absoluteCorners.forEach((corner, index) => {
+			const controlPointId = `${objectId}-cp-${index}`;
+			const circle = this.createControlPointCircle(
+				corner.x,
+				corner.y,
+				controlPointId,
+				objectId,
+				index,
+				true,
+			);
+			circle.set({ visible });
+			this.canvas.add(circle);
+			this.controlPoints.push({
+				id: controlPointId,
+				circle,
+				objectId,
+				pointIndex: index,
+			});
+		});
+
+		// Create edge midpoint control points (indices 8-11)
+		const edgeMidpoints = [
+			{
+				x: (absoluteCorners[0].x + absoluteCorners[1].x) / 2,
+				y: (absoluteCorners[0].y + absoluteCorners[1].y) / 2,
+				pointIndex: 8, // Top edge
+			},
+			{
+				x: (absoluteCorners[1].x + absoluteCorners[2].x) / 2,
+				y: (absoluteCorners[1].y + absoluteCorners[2].y) / 2,
+				pointIndex: 9, // Right edge
+			},
+			{
+				x: (absoluteCorners[2].x + absoluteCorners[3].x) / 2,
+				y: (absoluteCorners[2].y + absoluteCorners[3].y) / 2,
+				pointIndex: 10, // Bottom edge
+			},
+			{
+				x: (absoluteCorners[3].x + absoluteCorners[0].x) / 2,
+				y: (absoluteCorners[3].y + absoluteCorners[0].y) / 2,
+				pointIndex: 11, // Left edge
+			},
+		];
+
+		edgeMidpoints.forEach((midpoint) => {
+			const controlPointId = `${objectId}-cp-${midpoint.pointIndex}`;
+			const circle = this.createControlPointCircle(
+				midpoint.x,
+				midpoint.y,
+				controlPointId,
+				objectId,
+				midpoint.pointIndex,
+				true,
+			);
+			circle.set({ visible });
+			this.canvas.add(circle);
+			this.controlPoints.push({
+				id: controlPointId,
+				circle,
+				objectId,
+				pointIndex: midpoint.pointIndex,
+			});
+		});
+
+		// Create rotation handle (index 12) - floating, zoom-adjusted distance above the top edge in rotated space
+		const topMidpoint = edgeMidpoints[0]; // Top edge midpoint
+		const center = ellipse.getCenterPoint();
+		const vectorX = topMidpoint.x - center.x;
+		const vectorY = topMidpoint.y - center.y;
+		const vectorLength = Math.sqrt(vectorX * vectorX + vectorY * vectorY);
+		const normalizedX = vectorX / vectorLength;
+		const normalizedY = vectorY / vectorLength;
+		const rotationDistance = this.getRotationHandleDistance();
+		const rotationX =
+			center.x + normalizedX * (vectorLength + rotationDistance);
+		const rotationY =
+			center.y + normalizedY * (vectorLength + rotationDistance);
+		const rotationControlPointId = `${objectId}-cp-12`;
+		const rotationCircle = this.createControlPointCircle(
+			rotationX,
+			rotationY,
+			rotationControlPointId,
+			objectId,
+			12,
+			true,
+		);
+		rotationCircle.set({ visible, hoverCursor: 'crosshair' });
+		this.canvas.add(rotationCircle);
+		this.controlPoints.push({
+			id: rotationControlPointId,
+			circle: rotationCircle,
+			objectId,
+			pointIndex: 12,
+		});
+		// No connector line - rotation handle is floating
+
+		// Create light solid border lines (4 edges)
+		// Get current zoom to size edge lines correctly from the start
+		const zoom = this.canvas.getZoom();
+		const scale = 1 / zoom;
+
+		const edges = [
+			{ start: 0, end: 1 }, // Top
+			{ start: 1, end: 2 }, // Right
+			{ start: 2, end: 3 }, // Bottom
+			{ start: 3, end: 0 }, // Left
+		];
+
+		edges.forEach(({ start, end }, index) => {
+			const edgeId = `${objectId}-edge-${index}`;
+			const startCorner = absoluteCorners[start];
+			const endCorner = absoluteCorners[end];
+			const edgeLine = new fabric.Line(
+				[startCorner.x, startCorner.y, endCorner.x, endCorner.y],
+				{
+					stroke: 'oklch(0.8 0.05 39.0427)', // Light orange, reduced saturation
+					strokeWidth: 1.5 * scale,
+					selectable: false,
+					evented: false,
+					excludeFromExport: true,
+					visible,
+				},
+			);
+			(edgeLine as any).id = edgeId;
+			(edgeLine as any).linkedObjectId = objectId;
+			this.canvas.add(edgeLine);
+			this.edgeLines.set(edgeId, edgeLine);
+		});
+
+		this.bringControlPointsToFront();
+		this.canvas.renderAll();
+	}
+
+	removeControlPoints(objectId: string): void {
+		// Remove control points
+		const pointsToRemove = this.controlPoints.filter(
+			(cp) => cp.objectId === objectId,
+		);
+		pointsToRemove.forEach((cp) => {
+			this.canvas.remove(cp.circle);
+		});
+		this.controlPoints = this.controlPoints.filter(
+			(cp) => cp.objectId !== objectId,
+		);
+
+		// Remove edge lines
+		const edgeLinesToRemove: string[] = [];
+		this.edgeLines.forEach((line, id) => {
+			if ((line as any).linkedObjectId === objectId) {
+				this.canvas.remove(line);
+				edgeLinesToRemove.push(id);
+			}
+		});
+		edgeLinesToRemove.forEach((id) => this.edgeLines.delete(id));
+
+		this.canvas.renderAll();
+	}
+
+	hideControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => {
+			cp.circle.set({ visible: false });
+		});
+
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId) {
+				line.set({ visible: false });
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	hideAllControlPoints(): void {
+		// Hide all control point circles
+		this.controlPoints.forEach((cp) => {
+			cp.circle.set({ visible: false });
+		});
+
+		// Hide all edge lines
+		this.edgeLines.forEach((line) => {
+			line.set({ visible: false });
+		});
+
+		this.canvas.renderAll();
+	}
+
+	showControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => {
+			cp.circle.set({ visible: true });
+		});
+
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId) {
+				line.set({ visible: true });
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	updateControlPoints(objectId: string, obj: fabric.Object): void {
+		const ellipse = obj as fabric.Ellipse;
+		const controlPoints = this.getControlPointsForObject(objectId);
+		if (controlPoints.length === 0) return;
+
+		const rx = ellipse.rx || 0;
+		const ry = ellipse.ry || 0;
+		const strokeWidth = ellipse.strokeWidth || 0;
+
+		// Add padding to account for stroke width
+		const padding = strokeWidth / 2;
+
+		// Get transformation matrix for handling rotations/scaling
+		const matrix = ellipse.calcTransformMatrix();
+
+		// Define corners in local coordinates with padding
+		const corners = [
+			{ x: -(rx + padding), y: -(ry + padding) }, // Top-left
+			{ x: rx + padding, y: -(ry + padding) }, // Top-right
+			{ x: rx + padding, y: ry + padding }, // Bottom-right
+			{ x: -(rx + padding), y: ry + padding }, // Bottom-left
+		];
+
+		// Transform to absolute coordinates
+		const absoluteCorners = corners.map((corner) =>
+			fabric.util.transformPoint(new fabric.Point(corner.x, corner.y), matrix),
+		);
+
+		// Update corner control points (indices 0-3)
+		controlPoints.forEach((cp) => {
+			if (cp.pointIndex >= 0 && cp.pointIndex <= 3) {
+				const corner = absoluteCorners[cp.pointIndex];
+				cp.circle.set({ left: corner.x, top: corner.y });
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update edge midpoint control points (indices 8-11)
+		const edgeMidpoints = [
+			{
+				x: (absoluteCorners[0].x + absoluteCorners[1].x) / 2,
+				y: (absoluteCorners[0].y + absoluteCorners[1].y) / 2,
+				pointIndex: 8, // Top edge
+			},
+			{
+				x: (absoluteCorners[1].x + absoluteCorners[2].x) / 2,
+				y: (absoluteCorners[1].y + absoluteCorners[2].y) / 2,
+				pointIndex: 9, // Right edge
+			},
+			{
+				x: (absoluteCorners[2].x + absoluteCorners[3].x) / 2,
+				y: (absoluteCorners[2].y + absoluteCorners[3].y) / 2,
+				pointIndex: 10, // Bottom edge
+			},
+			{
+				x: (absoluteCorners[3].x + absoluteCorners[0].x) / 2,
+				y: (absoluteCorners[3].y + absoluteCorners[0].y) / 2,
+				pointIndex: 11, // Left edge
+			},
+		];
+
+		edgeMidpoints.forEach((midpoint) => {
+			const cp = controlPoints.find(
+				(cp) => cp.pointIndex === midpoint.pointIndex,
+			);
+			if (cp) {
+				cp.circle.set({ left: midpoint.x, top: midpoint.y });
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update rotation handle (index 12) - maintain 30px distance from top edge
+		const topMidpoint = edgeMidpoints[0];
+		const rotationCp = controlPoints.find((cp) => cp.pointIndex === 12);
+		if (rotationCp) {
+			// Calculate the vector from center to top midpoint
+			const center = ellipse.getCenterPoint();
+			const vectorX = topMidpoint.x - center.x;
+			const vectorY = topMidpoint.y - center.y;
+			const vectorLength = Math.sqrt(vectorX * vectorX + vectorY * vectorY);
+
+			// Normalize and extend by zoom-adjusted distance
+			const normalizedX = vectorX / vectorLength;
+			const normalizedY = vectorY / vectorLength;
+			const rotationDistance = this.getRotationHandleDistance();
+			const rotationX =
+				center.x + normalizedX * (vectorLength + rotationDistance);
+			const rotationY =
+				center.y + normalizedY * (vectorLength + rotationDistance);
+
+			rotationCp.circle.set({ left: rotationX, top: rotationY });
+			rotationCp.circle.setCoords();
+		}
+
+		// Update edge lines
+		const edges = [
+			{ start: 0, end: 1 }, // Top
+			{ start: 1, end: 2 }, // Right
+			{ start: 2, end: 3 }, // Bottom
+			{ start: 3, end: 0 }, // Left
+		];
+
+		edges.forEach(({ start, end }, index) => {
+			const edgeId = `${objectId}-edge-${index}`;
+			const edgeLine = this.edgeLines.get(edgeId);
+			if (edgeLine) {
+				const startCorner = absoluteCorners[start];
+				const endCorner = absoluteCorners[end];
+				edgeLine.set({
+					x1: startCorner.x,
+					y1: startCorner.y,
+					x2: endCorner.x,
+					y2: endCorner.y,
+				});
+				edgeLine.setCoords();
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	updateObjectFromControlPoint(
+		controlPointId: string,
+		newX: number,
+		newY: number,
+	): void {
+		const controlPoint = this.controlPoints.find(
+			(cp) => cp.id === controlPointId,
+		);
+		if (!controlPoint) return;
+
+		// Update the control point position immediately
+		controlPoint.circle.set({ left: newX, top: newY });
+		controlPoint.circle.setCoords();
+
+		// Handle different control point types
+		if (controlPoint.pointIndex >= 0 && controlPoint.pointIndex <= 3) {
+			// Corner control point - diagonal scaling
+			this.updateFromCorner(controlPoint, newX, newY);
+		} else if (controlPoint.pointIndex >= 8 && controlPoint.pointIndex <= 11) {
+			// Edge midpoint - stretch
+			this.updateFromEdge(controlPoint, newX, newY);
+		} else if (controlPoint.pointIndex === 12) {
+			// Rotation handle
+			this.updateFromRotation(controlPoint, newX, newY);
+		}
+	}
+
+	private updateFromCorner(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const ellipse = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) =>
+					obj.id === controlPoint.objectId && obj.type === 'ellipse',
+			) as fabric.Ellipse | undefined;
+		if (!ellipse) return;
+
+		const rx = ellipse.rx || 0;
+		const ry = ellipse.ry || 0;
+		const strokeWidth = ellipse.strokeWidth || 0;
+		const padding = strokeWidth / 2;
+		const angle = ellipse.angle || 0;
+		const angleRad = (angle * Math.PI) / 180;
+
+		// Calculate the four corners in absolute coordinates (with padding to match control points)
+		const matrix = ellipse.calcTransformMatrix();
+		const corners: fabric.Point[] = [
+			new fabric.Point(-(rx + padding), -(ry + padding)), // Top-left (0)
+			new fabric.Point(rx + padding, -(ry + padding)), // Top-right (1)
+			new fabric.Point(rx + padding, ry + padding), // Bottom-right (2)
+			new fabric.Point(-(rx + padding), ry + padding), // Bottom-left (3)
+		].map((corner) => fabric.util.transformPoint(corner, matrix));
+
+		// Determine which corner is the opposite/anchor corner
+		const oppositeCornerIndex = (controlPoint.pointIndex + 2) % 4;
+		const anchorCorner = corners[oppositeCornerIndex];
+
+		// Get the anchor corner control point's actual position
+		const anchorCornerCP = this.getControlPointsForObject(
+			controlPoint.objectId,
+		).find((cp) => cp.pointIndex === oppositeCornerIndex);
+		const anchorPosition = anchorCornerCP
+			? anchorCornerCP.circle.getCenterPoint()
+			: anchorCorner;
+
+		// The new dragged position
+		const draggedCorner = new fabric.Point(newX, newY);
+
+		// Vector from anchor to dragged corner
+		const vectorX = draggedCorner.x - anchorPosition.x;
+		const vectorY = draggedCorner.y - anchorPosition.y;
+
+		// Project this vector onto the rotated width and height axes
+		// Width axis (rotated horizontal)
+		const widthAxisX = Math.cos(angleRad);
+		const widthAxisY = Math.sin(angleRad);
+		const widthProjection = vectorX * widthAxisX + vectorY * widthAxisY;
+
+		// Height axis (rotated vertical)
+		const heightAxisX = -Math.sin(angleRad);
+		const heightAxisY = Math.cos(angleRad);
+		const heightProjection = vectorX * heightAxisX + vectorY * heightAxisY;
+
+		// New dimensions (subtract padding from projection, minimum 10px)
+		const newRx = Math.max(10, Math.abs(widthProjection) / 2 - padding);
+		const newRy = Math.max(10, Math.abs(heightProjection) / 2 - padding);
+
+		// New center is halfway between anchor and dragged corner
+		const newCenterX =
+			anchorPosition.x +
+			(widthProjection * widthAxisX) / 2 +
+			(heightProjection * heightAxisX) / 2;
+		const newCenterY =
+			anchorPosition.y +
+			(widthProjection * widthAxisY) / 2 +
+			(heightProjection * heightAxisY) / 2;
+
+		// Store ellipse properties
+		const ellipseId = (ellipse as any).id;
+		const ellipseProps = {
+			fill: ellipse.fill,
+			stroke: ellipse.stroke,
+			strokeWidth: ellipse.strokeWidth,
+			strokeDashArray: ellipse.strokeDashArray,
+			opacity: ellipse.opacity,
+			angle: angle,
+		};
+
+		// Remove old ellipse
+		this.canvas.remove(ellipse);
+
+		// Create new ellipse
+		const newEllipse = new fabric.Ellipse({
+			id: ellipseId,
+			left: newCenterX,
+			top: newCenterY,
+			rx: newRx,
+			ry: newRy,
+			fill: ellipseProps.fill,
+			stroke: ellipseProps.stroke,
+			strokeWidth: ellipseProps.strokeWidth,
+			strokeDashArray: ellipseProps.strokeDashArray,
+			opacity: ellipseProps.opacity,
+			angle: ellipseProps.angle,
+			selectable: true,
+			hasControls: false,
+			hasBorders: false,
+			strokeUniform: true,
+			originX: 'center',
+			originY: 'center',
+		});
+
+		this.canvas.add(newEllipse);
+		this.bringControlPointsToFront();
+		this.updateControlPoints(controlPoint.objectId, newEllipse);
+
+		this.canvas.renderAll();
+	}
+
+	private updateFromEdge(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const ellipse = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) =>
+					obj.id === controlPoint.objectId && obj.type === 'ellipse',
+			) as fabric.Ellipse | undefined;
+		if (!ellipse) return;
+
+		const rx = ellipse.rx || 0;
+		const ry = ellipse.ry || 0;
+		const angle = ellipse.angle || 0;
+		const center = ellipse.getCenterPoint();
+
+		// Convert angle to radians
+		const angleRad = (angle * Math.PI) / 180;
+
+		const newPoint = new fabric.Point(newX, newY);
+
+		// Determine which dimension to change and how to move the center
+		let newRx = rx;
+		let newRy = ry;
+		let newCenterX = center.x;
+		let newCenterY = center.y;
+
+		switch (controlPoint.pointIndex) {
+			case 8: // Top edge
+			case 10: {
+				// Bottom edge
+				// Direction perpendicular to the edge (pointing inward/outward)
+				const perpX = -Math.sin(angleRad);
+				const perpY = Math.cos(angleRad);
+				// For top edge (8), perpendicular points up (negative in local coords)
+				// For bottom edge (10), perpendicular points down (positive in local coords)
+				const edgeSign = controlPoint.pointIndex === 8 ? -1 : 1;
+				// Calculate where the opposite edge currently is
+				const oppositeEdgeOffset = ry * -edgeSign;
+				const oppositeEdgeX = center.x + perpX * oppositeEdgeOffset;
+				const oppositeEdgeY = center.y + perpY * oppositeEdgeOffset;
+				// Distance from new mouse position to opposite edge (in perpendicular direction)
+				const distanceFromOpposite =
+					(newPoint.x - oppositeEdgeX) * perpX +
+					(newPoint.y - oppositeEdgeY) * perpY;
+				// New ry is half this distance
+				newRy = Math.max(10, Math.abs(distanceFromOpposite) / 2);
+				// New center is halfway between mouse and opposite edge
+				newCenterX = oppositeEdgeX + (perpX * distanceFromOpposite) / 2;
+				newCenterY = oppositeEdgeY + (perpY * distanceFromOpposite) / 2;
+				break;
+			}
+			case 9: // Right edge
+			case 11: {
+				// Left edge
+				// Direction perpendicular to the edge (pointing inward/outward)
+				const perpX = Math.cos(angleRad);
+				const perpY = Math.sin(angleRad);
+				// For left edge (11), perpendicular points left (negative in local coords)
+				// For right edge (9), perpendicular points right (positive in local coords)
+				const edgeSign = controlPoint.pointIndex === 11 ? -1 : 1;
+				// Calculate where the opposite edge currently is
+				const oppositeEdgeOffset = rx * -edgeSign;
+				const oppositeEdgeX = center.x + perpX * oppositeEdgeOffset;
+				const oppositeEdgeY = center.y + perpY * oppositeEdgeOffset;
+				// Distance from new mouse position to opposite edge (in perpendicular direction)
+				const distanceFromOpposite =
+					(newPoint.x - oppositeEdgeX) * perpX +
+					(newPoint.y - oppositeEdgeY) * perpY;
+				// New rx is half this distance
+				newRx = Math.max(10, Math.abs(distanceFromOpposite) / 2);
+				// New center is halfway between mouse and opposite edge
+				newCenterX = oppositeEdgeX + (perpX * distanceFromOpposite) / 2;
+				newCenterY = oppositeEdgeY + (perpY * distanceFromOpposite) / 2;
+				break;
+			}
+		}
+
+		// Store ellipse properties
+		const ellipseId = (ellipse as any).id;
+		const ellipseProps = {
+			fill: ellipse.fill,
+			stroke: ellipse.stroke,
+			strokeWidth: ellipse.strokeWidth,
+			strokeDashArray: ellipse.strokeDashArray,
+			opacity: ellipse.opacity,
+			angle: angle,
+		};
+
+		// Remove old ellipse
+		this.canvas.remove(ellipse);
+
+		// Create new ellipse with updated center and dimensions
+		const newEllipse = new fabric.Ellipse({
+			id: ellipseId,
+			left: newCenterX,
+			top: newCenterY,
+			rx: newRx,
+			ry: newRy,
+			fill: ellipseProps.fill,
+			stroke: ellipseProps.stroke,
+			strokeWidth: ellipseProps.strokeWidth,
+			strokeDashArray: ellipseProps.strokeDashArray,
+			opacity: ellipseProps.opacity,
+			angle: ellipseProps.angle,
+			selectable: true,
+			hasControls: false,
+			hasBorders: false,
+			strokeUniform: true,
+			originX: 'center',
+			originY: 'center',
+		});
+
+		this.canvas.add(newEllipse);
+		this.bringControlPointsToFront();
+		this.updateControlPoints(controlPoint.objectId, newEllipse);
+		this.canvas.renderAll();
+	}
+
+	private updateFromRotation(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const ellipse = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) =>
+					obj.id === controlPoint.objectId && obj.type === 'ellipse',
+			) as fabric.Ellipse | undefined;
+		if (!ellipse) return;
+
+		const center = ellipse.getCenterPoint();
+
+		// Calculate angle from center to rotation handle
+		const dx = newX - center.x;
+		const dy = newY - center.y;
+		const angleRad = Math.atan2(dy, dx);
+		const angleDeg = (angleRad * 180) / Math.PI + 90; // Add 90 to align with top
+
+		// Update ellipse rotation
+		ellipse.set({ angle: angleDeg });
+		ellipse.setCoords();
+
+		// Update control points
+		this.updateControlPoints(controlPoint.objectId, ellipse);
+		this.canvas.renderAll();
+	}
+}
+
+/**
+ * Control point handler for triangles
+ */
+export class TriangleControlPoints extends BoundingBoxControlPoints {
+	addControlPoints(
+		objectId: string,
+		obj: fabric.Object,
+		visible: boolean = true,
+	): void {
+		const triangle = obj as fabric.Triangle;
+		const width = triangle.width || 0;
+		const height = triangle.height || 0;
+		const strokeWidth = triangle.strokeWidth || 0;
+
+		// Add padding to account for stroke width
+		const padding = strokeWidth / 2;
+
+		// Get transformation matrix for handling rotations/scaling
+		const matrix = triangle.calcTransformMatrix();
+
+		// Define the 4 corners of the bounding rectangle in local coordinates with padding
+		const corners = [
+			{ x: -(width / 2 + padding), y: -(height / 2 + padding) }, // Top-left
+			{ x: width / 2 + padding, y: -(height / 2 + padding) }, // Top-right
+			{ x: width / 2 + padding, y: height / 2 + padding }, // Bottom-right
+			{ x: -(width / 2 + padding), y: height / 2 + padding }, // Bottom-left
+		];
+
+		// Transform corners to absolute coordinates
+		const absoluteCorners = corners.map((corner) =>
+			fabric.util.transformPoint(new fabric.Point(corner.x, corner.y), matrix),
+		);
+
+		// Create control points at corners (indices 0-3)
+		absoluteCorners.forEach((corner, index) => {
+			const controlPointId = `${objectId}-cp-${index}`;
+			const circle = this.createControlPointCircle(
+				corner.x,
+				corner.y,
+				controlPointId,
+				objectId,
+				index,
+				true,
+			);
+			circle.set({ visible });
+			this.canvas.add(circle);
+			this.controlPoints.push({
+				id: controlPointId,
+				circle,
+				objectId,
+				pointIndex: index,
+			});
+		});
+
+		// Create edge midpoint control points (indices 8-11)
+		const edgeMidpoints = [
+			{
+				x: (absoluteCorners[0].x + absoluteCorners[1].x) / 2,
+				y: (absoluteCorners[0].y + absoluteCorners[1].y) / 2,
+				pointIndex: 8, // Top edge
+			},
+			{
+				x: (absoluteCorners[1].x + absoluteCorners[2].x) / 2,
+				y: (absoluteCorners[1].y + absoluteCorners[2].y) / 2,
+				pointIndex: 9, // Right edge
+			},
+			{
+				x: (absoluteCorners[2].x + absoluteCorners[3].x) / 2,
+				y: (absoluteCorners[2].y + absoluteCorners[3].y) / 2,
+				pointIndex: 10, // Bottom edge
+			},
+			{
+				x: (absoluteCorners[3].x + absoluteCorners[0].x) / 2,
+				y: (absoluteCorners[3].y + absoluteCorners[0].y) / 2,
+				pointIndex: 11, // Left edge
+			},
+		];
+
+		edgeMidpoints.forEach((midpoint) => {
+			const controlPointId = `${objectId}-cp-${midpoint.pointIndex}`;
+			const circle = this.createControlPointCircle(
+				midpoint.x,
+				midpoint.y,
+				controlPointId,
+				objectId,
+				midpoint.pointIndex,
+				true,
+			);
+			circle.set({ visible });
+			this.canvas.add(circle);
+			this.controlPoints.push({
+				id: controlPointId,
+				circle,
+				objectId,
+				pointIndex: midpoint.pointIndex,
+			});
+		});
+
+		// Create rotation handle (index 12) - floating, zoom-adjusted distance above the top edge in rotated space
+		const topMidpoint = edgeMidpoints[0]; // Top edge midpoint
+		const center = triangle.getCenterPoint();
+		const vectorX = topMidpoint.x - center.x;
+		const vectorY = topMidpoint.y - center.y;
+		const vectorLength = Math.sqrt(vectorX * vectorX + vectorY * vectorY);
+		const normalizedX = vectorX / vectorLength;
+		const normalizedY = vectorY / vectorLength;
+		const rotationDistance = this.getRotationHandleDistance();
+		const rotationX =
+			center.x + normalizedX * (vectorLength + rotationDistance);
+		const rotationY =
+			center.y + normalizedY * (vectorLength + rotationDistance);
+		const rotationControlPointId = `${objectId}-cp-12`;
+		const rotationCircle = this.createControlPointCircle(
+			rotationX,
+			rotationY,
+			rotationControlPointId,
+			objectId,
+			12,
+			true,
+		);
+		rotationCircle.set({ visible, hoverCursor: 'crosshair' });
+		this.canvas.add(rotationCircle);
+		this.controlPoints.push({
+			id: rotationControlPointId,
+			circle: rotationCircle,
+			objectId,
+			pointIndex: 12,
+		});
+
+		// Create light solid border lines (4 edges)
+		// Get current zoom to size edge lines correctly from the start
+		const zoom = this.canvas.getZoom();
+		const scale = 1 / zoom;
+
+		const edges = [
+			{ start: 0, end: 1 }, // Top
+			{ start: 1, end: 2 }, // Right
+			{ start: 2, end: 3 }, // Bottom
+			{ start: 3, end: 0 }, // Left
+		];
+
+		edges.forEach(({ start, end }, index) => {
+			const edgeId = `${objectId}-edge-${index}`;
+			const startCorner = absoluteCorners[start];
+			const endCorner = absoluteCorners[end];
+			const edgeLine = new fabric.Line(
+				[startCorner.x, startCorner.y, endCorner.x, endCorner.y],
+				{
+					stroke: 'oklch(0.8 0.05 39.0427)', // Light orange, reduced saturation
+					strokeWidth: 1.5 * scale,
+					selectable: false,
+					evented: false,
+					excludeFromExport: true,
+					visible,
+				},
+			);
+			(edgeLine as any).id = edgeId;
+			(edgeLine as any).linkedObjectId = objectId;
+			this.canvas.add(edgeLine);
+			this.edgeLines.set(edgeId, edgeLine);
+		});
+
+		this.bringControlPointsToFront();
+		this.canvas.renderAll();
+	}
+
+	removeControlPoints(objectId: string): void {
+		// Remove control points
+		const pointsToRemove = this.controlPoints.filter(
+			(cp) => cp.objectId === objectId,
+		);
+		pointsToRemove.forEach((cp) => {
+			this.canvas.remove(cp.circle);
+		});
+		this.controlPoints = this.controlPoints.filter(
+			(cp) => cp.objectId !== objectId,
+		);
+
+		// Remove edge lines
+		const edgeLinesToRemove: string[] = [];
+		this.edgeLines.forEach((line, id) => {
+			if ((line as any).linkedObjectId === objectId) {
+				this.canvas.remove(line);
+				edgeLinesToRemove.push(id);
+			}
+		});
+		edgeLinesToRemove.forEach((id) => this.edgeLines.delete(id));
+
+		this.canvas.renderAll();
+	}
+
+	hideControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => {
+			cp.circle.set({ visible: false });
+		});
+
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId) {
+				line.set({ visible: false });
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	hideAllControlPoints(): void {
+		// Hide all control point circles
+		this.controlPoints.forEach((cp) => {
+			cp.circle.set({ visible: false });
+		});
+
+		// Hide all edge lines
+		this.edgeLines.forEach((line) => {
+			line.set({ visible: false });
+		});
+
+		this.canvas.renderAll();
+	}
+
+	showControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => {
+			cp.circle.set({ visible: true });
+		});
+
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId) {
+				line.set({ visible: true });
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	updateControlPoints(objectId: string, obj: fabric.Object): void {
+		const triangle = obj as fabric.Triangle;
+		const controlPoints = this.getControlPointsForObject(objectId);
+		if (controlPoints.length === 0) return;
+
+		const width = triangle.width || 0;
+		const height = triangle.height || 0;
+		const strokeWidth = triangle.strokeWidth || 0;
+
+		// Add padding to account for stroke width
+		const padding = strokeWidth / 2;
+
+		// Get transformation matrix for handling rotations/scaling
+		const matrix = triangle.calcTransformMatrix();
+
+		// Define corners in local coordinates with padding
+		const corners = [
+			{ x: -(width / 2 + padding), y: -(height / 2 + padding) }, // Top-left
+			{ x: width / 2 + padding, y: -(height / 2 + padding) }, // Top-right
+			{ x: width / 2 + padding, y: height / 2 + padding }, // Bottom-right
+			{ x: -(width / 2 + padding), y: height / 2 + padding }, // Bottom-left
+		];
+
+		// Transform to absolute coordinates
+		const absoluteCorners = corners.map((corner) =>
+			fabric.util.transformPoint(new fabric.Point(corner.x, corner.y), matrix),
+		);
+
+		// Update corner control points (indices 0-3)
+		controlPoints.forEach((cp) => {
+			if (cp.pointIndex >= 0 && cp.pointIndex <= 3) {
+				const corner = absoluteCorners[cp.pointIndex];
+				cp.circle.set({ left: corner.x, top: corner.y });
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update edge midpoint control points (indices 8-11)
+		const edgeMidpoints = [
+			{
+				x: (absoluteCorners[0].x + absoluteCorners[1].x) / 2,
+				y: (absoluteCorners[0].y + absoluteCorners[1].y) / 2,
+				pointIndex: 8, // Top edge
+			},
+			{
+				x: (absoluteCorners[1].x + absoluteCorners[2].x) / 2,
+				y: (absoluteCorners[1].y + absoluteCorners[2].y) / 2,
+				pointIndex: 9, // Right edge
+			},
+			{
+				x: (absoluteCorners[2].x + absoluteCorners[3].x) / 2,
+				y: (absoluteCorners[2].y + absoluteCorners[3].y) / 2,
+				pointIndex: 10, // Bottom edge
+			},
+			{
+				x: (absoluteCorners[3].x + absoluteCorners[0].x) / 2,
+				y: (absoluteCorners[3].y + absoluteCorners[0].y) / 2,
+				pointIndex: 11, // Left edge
+			},
+		];
+
+		edgeMidpoints.forEach((midpoint) => {
+			const cp = controlPoints.find(
+				(cp) => cp.pointIndex === midpoint.pointIndex,
+			);
+			if (cp) {
+				cp.circle.set({ left: midpoint.x, top: midpoint.y });
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update rotation handle (index 12) - maintain 30px distance from top edge
+		const topMidpoint = edgeMidpoints[0];
+		const rotationCp = controlPoints.find((cp) => cp.pointIndex === 12);
+		if (rotationCp) {
+			// Calculate the vector from center to top midpoint
+			const center = triangle.getCenterPoint();
+			const vectorX = topMidpoint.x - center.x;
+			const vectorY = topMidpoint.y - center.y;
+			const vectorLength = Math.sqrt(vectorX * vectorX + vectorY * vectorY);
+
+			// Normalize and extend by 30px
+			const normalizedX = vectorX / vectorLength;
+			const normalizedY = vectorY / vectorLength;
+			const rotationX = center.x + normalizedX * (vectorLength + 30);
+			const rotationY = center.y + normalizedY * (vectorLength + 30);
+
+			rotationCp.circle.set({ left: rotationX, top: rotationY });
+			rotationCp.circle.setCoords();
+		}
+
+		// Update edge lines
+		const edges = [
+			{ start: 0, end: 1 }, // Top
+			{ start: 1, end: 2 }, // Right
+			{ start: 2, end: 3 }, // Bottom
+			{ start: 3, end: 0 }, // Left
+		];
+
+		edges.forEach(({ start, end }, index) => {
+			const edgeId = `${objectId}-edge-${index}`;
+			const edgeLine = this.edgeLines.get(edgeId);
+			if (edgeLine) {
+				const startCorner = absoluteCorners[start];
+				const endCorner = absoluteCorners[end];
+				edgeLine.set({
+					x1: startCorner.x,
+					y1: startCorner.y,
+					x2: endCorner.x,
+					y2: endCorner.y,
+				});
+				edgeLine.setCoords();
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	updateObjectFromControlPoint(
+		controlPointId: string,
+		newX: number,
+		newY: number,
+	): void {
+		const controlPoint = this.controlPoints.find(
+			(cp) => cp.id === controlPointId,
+		);
+		if (!controlPoint) return;
+
+		// Update the control point position immediately
+		controlPoint.circle.set({ left: newX, top: newY });
+		controlPoint.circle.setCoords();
+
+		// Handle different control point types
+		if (controlPoint.pointIndex >= 0 && controlPoint.pointIndex <= 3) {
+			// Corner control point - diagonal scaling
+			this.updateFromCorner(controlPoint, newX, newY);
+		} else if (controlPoint.pointIndex >= 8 && controlPoint.pointIndex <= 11) {
+			// Edge midpoint - stretch
+			this.updateFromEdge(controlPoint, newX, newY);
+		} else if (controlPoint.pointIndex === 12) {
+			// Rotation handle
+			this.updateFromRotation(controlPoint, newX, newY);
+		}
+	}
+
+	private updateFromCorner(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const triangle = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) =>
+					obj.id === controlPoint.objectId && obj.type === 'triangle',
+			) as fabric.Triangle | undefined;
+		if (!triangle) return;
+
+		const width = triangle.width || 0;
+		const height = triangle.height || 0;
+		const strokeWidth = triangle.strokeWidth || 0;
+		const padding = strokeWidth / 2;
+		const angle = triangle.angle || 0;
+		const angleRad = (angle * Math.PI) / 180;
+
+		// Calculate the four corners in absolute coordinates (with padding to match control points)
+		const matrix = triangle.calcTransformMatrix();
+		const corners: fabric.Point[] = [
+			new fabric.Point(-(width / 2 + padding), -(height / 2 + padding)), // Top-left (0)
+			new fabric.Point(width / 2 + padding, -(height / 2 + padding)), // Top-right (1)
+			new fabric.Point(width / 2 + padding, height / 2 + padding), // Bottom-right (2)
+			new fabric.Point(-(width / 2 + padding), height / 2 + padding), // Bottom-left (3)
+		].map((corner) => fabric.util.transformPoint(corner, matrix));
+
+		// Determine which corner is the opposite/anchor corner
+		const oppositeCornerIndex = (controlPoint.pointIndex + 2) % 4;
+		const anchorCorner = corners[oppositeCornerIndex];
+
+		// Get the anchor corner control point's actual position
+		const anchorCornerCP = this.getControlPointsForObject(
+			controlPoint.objectId,
+		).find((cp) => cp.pointIndex === oppositeCornerIndex);
+		const anchorPosition = anchorCornerCP
+			? anchorCornerCP.circle.getCenterPoint()
+			: anchorCorner;
+
+		// The new dragged position
+		const draggedCorner = new fabric.Point(newX, newY);
+
+		// Vector from anchor to dragged corner
+		const vectorX = draggedCorner.x - anchorPosition.x;
+		const vectorY = draggedCorner.y - anchorPosition.y;
+
+		// Project this vector onto the rotated width and height axes
+		const widthAxisX = Math.cos(angleRad);
+		const widthAxisY = Math.sin(angleRad);
+		const widthProjection = vectorX * widthAxisX + vectorY * widthAxisY;
+
+		const heightAxisX = -Math.sin(angleRad);
+		const heightAxisY = Math.cos(angleRad);
+		const heightProjection = vectorX * heightAxisX + vectorY * heightAxisY;
+
+		// New dimensions (subtract padding from projection)
+		const newWidth = Math.max(10, Math.abs(widthProjection) - 2 * padding);
+		const newHeight = Math.max(10, Math.abs(heightProjection) - 2 * padding);
+
+		// New center is halfway between anchor and dragged corner
+		const newCenterX =
+			anchorPosition.x +
+			(widthProjection * widthAxisX) / 2 +
+			(heightProjection * heightAxisX) / 2;
+		const newCenterY =
+			anchorPosition.y +
+			(widthProjection * widthAxisY) / 2 +
+			(heightProjection * heightAxisY) / 2;
+
+		// Store triangle properties
+		const triangleId = (triangle as any).id;
+		const triangleProps = {
+			fill: triangle.fill,
+			stroke: triangle.stroke,
+			strokeWidth: triangle.strokeWidth,
+			strokeDashArray: triangle.strokeDashArray,
+			opacity: triangle.opacity,
+			angle: angle,
+		};
+
+		// Remove old triangle
+		this.canvas.remove(triangle);
+
+		// Create new triangle
+		const newTriangle = new fabric.Triangle({
+			id: triangleId,
+			left: newCenterX,
+			top: newCenterY,
+			width: newWidth,
+			height: newHeight,
+			fill: triangleProps.fill,
+			stroke: triangleProps.stroke,
+			strokeWidth: triangleProps.strokeWidth,
+			strokeDashArray: triangleProps.strokeDashArray,
+			opacity: triangleProps.opacity,
+			angle: triangleProps.angle,
+			selectable: true,
+			hasControls: false,
+			hasBorders: false,
+			strokeUniform: true,
+			originX: 'center',
+			originY: 'center',
+		});
+
+		this.canvas.add(newTriangle);
+		this.bringControlPointsToFront();
+		this.updateControlPoints(controlPoint.objectId, newTriangle);
+
+		this.canvas.renderAll();
+	}
+
+	private updateFromEdge(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const triangle = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) =>
+					obj.id === controlPoint.objectId && obj.type === 'triangle',
+			) as fabric.Triangle | undefined;
+		if (!triangle) return;
+
+		const width = triangle.width || 0;
+		const height = triangle.height || 0;
+		const angle = triangle.angle || 0;
+		const center = triangle.getCenterPoint();
+
+		// Convert angle to radians
+		const angleRad = (angle * Math.PI) / 180;
+
+		const newPoint = new fabric.Point(newX, newY);
+
+		// Determine which dimension to change and how to move the center
+		let newWidth = width;
+		let newHeight = height;
+		let newCenterX = center.x;
+		let newCenterY = center.y;
+
+		switch (controlPoint.pointIndex) {
+			case 8: // Top edge
+			case 10: {
+				// Bottom edge
+				// Direction perpendicular to the edge
+				const perpX = -Math.sin(angleRad);
+				const perpY = Math.cos(angleRad);
+				const edgeSign = controlPoint.pointIndex === 8 ? -1 : 1;
+				// Calculate where the opposite edge currently is
+				const oppositeEdgeOffset = (height / 2) * -edgeSign;
+				const oppositeEdgeX = center.x + perpX * oppositeEdgeOffset;
+				const oppositeEdgeY = center.y + perpY * oppositeEdgeOffset;
+				// Distance from new mouse position to opposite edge
+				const distanceFromOpposite =
+					(newPoint.x - oppositeEdgeX) * perpX +
+					(newPoint.y - oppositeEdgeY) * perpY;
+				// New height
+				newHeight = Math.max(10, Math.abs(distanceFromOpposite));
+				// New center is halfway between mouse and opposite edge
+				newCenterX = oppositeEdgeX + (perpX * distanceFromOpposite) / 2;
+				newCenterY = oppositeEdgeY + (perpY * distanceFromOpposite) / 2;
+				break;
+			}
+			case 9: // Right edge
+			case 11: {
+				// Left edge
+				// Direction perpendicular to the edge
+				const perpX = Math.cos(angleRad);
+				const perpY = Math.sin(angleRad);
+				const edgeSign = controlPoint.pointIndex === 11 ? -1 : 1;
+				// Calculate where the opposite edge currently is
+				const oppositeEdgeOffset = (width / 2) * -edgeSign;
+				const oppositeEdgeX = center.x + perpX * oppositeEdgeOffset;
+				const oppositeEdgeY = center.y + perpY * oppositeEdgeOffset;
+				// Distance from new mouse position to opposite edge
+				const distanceFromOpposite =
+					(newPoint.x - oppositeEdgeX) * perpX +
+					(newPoint.y - oppositeEdgeY) * perpY;
+				// New width
+				newWidth = Math.max(10, Math.abs(distanceFromOpposite));
+				// New center is halfway between mouse and opposite edge
+				newCenterX = oppositeEdgeX + (perpX * distanceFromOpposite) / 2;
+				newCenterY = oppositeEdgeY + (perpY * distanceFromOpposite) / 2;
+				break;
+			}
+		}
+
+		// Store triangle properties
+		const triangleId = (triangle as any).id;
+		const triangleProps = {
+			fill: triangle.fill,
+			stroke: triangle.stroke,
+			strokeWidth: triangle.strokeWidth,
+			strokeDashArray: triangle.strokeDashArray,
+			opacity: triangle.opacity,
+			angle: angle,
+		};
+
+		// Remove old triangle
+		this.canvas.remove(triangle);
+
+		// Create new triangle with updated center and dimensions
+		const newTriangle = new fabric.Triangle({
+			id: triangleId,
+			left: newCenterX,
+			top: newCenterY,
+			width: newWidth,
+			height: newHeight,
+			fill: triangleProps.fill,
+			stroke: triangleProps.stroke,
+			strokeWidth: triangleProps.strokeWidth,
+			strokeDashArray: triangleProps.strokeDashArray,
+			opacity: triangleProps.opacity,
+			angle: triangleProps.angle,
+			selectable: true,
+			hasControls: false,
+			hasBorders: false,
+			strokeUniform: true,
+			originX: 'center',
+			originY: 'center',
+		});
+
+		this.canvas.add(newTriangle);
+		this.bringControlPointsToFront();
+		this.updateControlPoints(controlPoint.objectId, newTriangle);
+		this.canvas.renderAll();
+	}
+
+	private updateFromRotation(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const triangle = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) =>
+					obj.id === controlPoint.objectId && obj.type === 'triangle',
+			) as fabric.Triangle | undefined;
+		if (!triangle) return;
+
+		const center = triangle.getCenterPoint();
+
+		// Calculate angle from center to rotation handle
+		const dx = newX - center.x;
+		const dy = newY - center.y;
+		const angleRad = Math.atan2(dy, dx);
+		const angleDeg = (angleRad * 180) / Math.PI + 90; // Add 90 to align with top
+
+		// Update triangle rotation
+		triangle.set({ angle: angleDeg });
+		triangle.setCoords();
+
+		// Update control points
+		this.updateControlPoints(controlPoint.objectId, triangle);
+		this.canvas.renderAll();
+	}
+}
+
+/**
+ * Control point handler for textboxes
+ */
+export class TextboxControlPoints extends BoundingBoxControlPoints {
+	addControlPoints(
+		objectId: string,
+		obj: fabric.Object,
+		visible: boolean = true,
+	): void {
+		const textbox = obj as fabric.Textbox;
+		const width = textbox.width || 0;
+		const height = textbox.height || 0;
+		const left = textbox.left || 0;
+		const top = textbox.top || 0;
+		const angle = textbox.angle || 0;
+		const angleRad = (angle * Math.PI) / 180;
+
+		// Add padding to account for text overflow (descenders, etc.)
+		const padding = 3;
+
+		// Calculate the four corners by rotating around top-left origin
+		const cos = Math.cos(angleRad);
+		const sin = Math.sin(angleRad);
+
+		// Define corners in local space (before rotation) with padding
+		const localCorners = [
+			{ x: -padding, y: -padding }, // Top-left
+			{ x: width + padding, y: -padding }, // Top-right
+			{ x: width + padding, y: height + padding }, // Bottom-right
+			{ x: -padding, y: height + padding }, // Bottom-left
+		];
+
+		// Rotate each corner around the origin (top-left) and add the textbox position
+		const corners = localCorners.map((corner) => ({
+			x: left + corner.x * cos - corner.y * sin,
+			y: top + corner.x * sin + corner.y * cos,
+		}));
+
+		// Create control points at corners (indices 0-3)
+		corners.forEach((corner, index) => {
+			const controlPointId = `${objectId}-cp-${index}`;
+			const circle = this.createControlPointCircle(
+				corner.x,
+				corner.y,
+				controlPointId,
+				objectId,
+				index,
+				true,
+			);
+			circle.set({ visible });
+			this.canvas.add(circle);
+			this.controlPoints.push({
+				id: controlPointId,
+				circle,
+				objectId,
+				pointIndex: index,
+			});
+		});
+
+		// Create edge midpoint control points (indices 8-11)
+		const edgeMidpoints = [
+			{
+				x: (corners[0].x + corners[1].x) / 2,
+				y: (corners[0].y + corners[1].y) / 2,
+				pointIndex: 8, // Top edge
+			},
+			{
+				x: (corners[1].x + corners[2].x) / 2,
+				y: (corners[1].y + corners[2].y) / 2,
+				pointIndex: 9, // Right edge
+			},
+			{
+				x: (corners[2].x + corners[3].x) / 2,
+				y: (corners[2].y + corners[3].y) / 2,
+				pointIndex: 10, // Bottom edge
+			},
+			{
+				x: (corners[3].x + corners[0].x) / 2,
+				y: (corners[3].y + corners[0].y) / 2,
+				pointIndex: 11, // Left edge
+			},
+		];
+
+		edgeMidpoints.forEach((midpoint) => {
+			const controlPointId = `${objectId}-cp-${midpoint.pointIndex}`;
+			const circle = this.createControlPointCircle(
+				midpoint.x,
+				midpoint.y,
+				controlPointId,
+				objectId,
+				midpoint.pointIndex,
+				true,
+			);
+			circle.set({ visible });
+			this.canvas.add(circle);
+			this.controlPoints.push({
+				id: controlPointId,
+				circle,
+				objectId,
+				pointIndex: midpoint.pointIndex,
+			});
+		});
+
+		// DISABLED: Rotation control point for text objects due to bugs
+		/*
+// Create rotation handle (index 12)
+const topMidpoint = edgeMidpoints[0]
+const rotationY = topMidpoint.y - 30
+const rotationControlPointId = `${objectId}-cp-12`
+const rotationCircle = this.createControlPointCircle(
+topMidpoint.x,
+rotationY,
+rotationControlPointId,
+objectId,
+12,
+true
+)
+rotationCircle.set({ visible, hoverCursor: 'crosshair' })
+this.canvas.add(rotationCircle)
+this.controlPoints.push({
+id: rotationControlPointId,
+circle: rotationCircle,
+objectId,
+pointIndex: 12
+})
+*/
+
+		// Create border lines
+		const zoom = this.canvas.getZoom();
+		const scale = 1 / zoom;
+
+		const edges = [
+			{ start: 0, end: 1 }, // Top
+			{ start: 1, end: 2 }, // Right
+			{ start: 2, end: 3 }, // Bottom
+			{ start: 3, end: 0 }, // Left
+		];
+
+		edges.forEach(({ start, end }, index) => {
+			const edgeId = `${objectId}-edge-${index}`;
+			const startCorner = corners[start];
+			const endCorner = corners[end];
+			const edgeLine = new fabric.Line(
+				[startCorner.x, startCorner.y, endCorner.x, endCorner.y],
+				{
+					stroke: 'oklch(0.8 0.05 39.0427)',
+					strokeWidth: 1.5 * scale,
+					selectable: false,
+					evented: false,
+					excludeFromExport: true,
+					visible,
+				},
+			);
+			(edgeLine as any).id = edgeId;
+			(edgeLine as any).linkedObjectId = objectId;
+			this.canvas.add(edgeLine);
+			this.edgeLines.set(edgeId, edgeLine);
+		});
+
+		this.bringControlPointsToFront();
+		this.canvas.renderAll();
+	}
+
+	removeControlPoints(objectId: string): void {
+		const pointsToRemove = this.controlPoints.filter(
+			(cp) => cp.objectId === objectId,
+		);
+		pointsToRemove.forEach((cp) => {
+			this.canvas.remove(cp.circle);
+		});
+		this.controlPoints = this.controlPoints.filter(
+			(cp) => cp.objectId !== objectId,
+		);
+
+		const edgeLinesToRemove: string[] = [];
+		this.edgeLines.forEach((line, id) => {
+			if ((line as any).linkedObjectId === objectId) {
+				this.canvas.remove(line);
+				edgeLinesToRemove.push(id);
+			}
+		});
+		edgeLinesToRemove.forEach((id) => this.edgeLines.delete(id));
+
+		this.canvas.renderAll();
+	}
+
+	hideControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => {
+			cp.circle.set({ visible: false });
+		});
+
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId) {
+				line.set({ visible: false });
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	showControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => {
+			cp.circle.set({ visible: true });
+		});
+
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId) {
+				line.set({ visible: true });
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	updateControlPoints(objectId: string, obj: fabric.Object): void {
+		const textbox = obj as fabric.Textbox;
+		const controlPoints = this.getControlPointsForObject(objectId);
+		if (controlPoints.length === 0) return;
+
+		const width = textbox.width || 0;
+		const height = textbox.height || 0;
+		const left = textbox.left || 0;
+		const top = textbox.top || 0;
+		const angle = textbox.angle || 0;
+		const angleRad = (angle * Math.PI) / 180;
+
+		// Add padding to account for text overflow
+		const padding = 3;
+
+		// Calculate the four corners by rotating around top-left origin
+		const cos = Math.cos(angleRad);
+		const sin = Math.sin(angleRad);
+
+		// Define corners in local space (before rotation) with padding
+		const localCorners = [
+			{ x: -padding, y: -padding }, // Top-left
+			{ x: width + padding, y: -padding }, // Top-right
+			{ x: width + padding, y: height + padding }, // Bottom-right
+			{ x: -padding, y: height + padding }, // Bottom-left
+		];
+
+		// Rotate each corner around the origin (top-left) and add the textbox position
+		const corners = localCorners.map((corner) => ({
+			x: left + corner.x * cos - corner.y * sin,
+			y: top + corner.x * sin + corner.y * cos,
+		}));
+
+		// Update corner control points
+		controlPoints.forEach((cp) => {
+			if (cp.pointIndex >= 0 && cp.pointIndex <= 3) {
+				const corner = corners[cp.pointIndex];
+				cp.circle.set({ left: corner.x, top: corner.y });
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update edge midpoints
+		const edgeMidpoints = [
+			{
+				x: (corners[0].x + corners[1].x) / 2,
+				y: (corners[0].y + corners[1].y) / 2,
+				pointIndex: 8,
+			},
+			{
+				x: (corners[1].x + corners[2].x) / 2,
+				y: (corners[1].y + corners[2].y) / 2,
+				pointIndex: 9,
+			},
+			{
+				x: (corners[2].x + corners[3].x) / 2,
+				y: (corners[2].y + corners[3].y) / 2,
+				pointIndex: 10,
+			},
+			{
+				x: (corners[3].x + corners[0].x) / 2,
+				y: (corners[3].y + corners[0].y) / 2,
+				pointIndex: 11,
+			},
+		];
+
+		edgeMidpoints.forEach((midpoint) => {
+			const cp = controlPoints.find(
+				(cp) => cp.pointIndex === midpoint.pointIndex,
+			);
+			if (cp) {
+				cp.circle.set({ left: midpoint.x, top: midpoint.y });
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update rotation handle
+		const topMidpoint = edgeMidpoints[0];
+		const rotationCp = controlPoints.find((cp) => cp.pointIndex === 12);
+		if (rotationCp) {
+			rotationCp.circle.set({ left: topMidpoint.x, top: topMidpoint.y - 30 });
+			rotationCp.circle.setCoords();
+		}
+
+		// Update edge lines
+		const edges = [
+			{ start: 0, end: 1 },
+			{ start: 1, end: 2 },
+			{ start: 2, end: 3 },
+			{ start: 3, end: 0 },
+		];
+
+		edges.forEach(({ start, end }, index) => {
+			const edgeId = `${objectId}-edge-${index}`;
+			const edgeLine = this.edgeLines.get(edgeId);
+			if (edgeLine) {
+				edgeLine.set({
+					x1: corners[start].x,
+					y1: corners[start].y,
+					x2: corners[end].x,
+					y2: corners[end].y,
+				});
+				edgeLine.setCoords();
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	updateObjectFromControlPoint(
+		controlPointId: string,
+		newX: number,
+		newY: number,
+	): void {
+		const controlPoint = this.controlPoints.find(
+			(cp) => cp.id === controlPointId,
+		);
+		if (!controlPoint) return;
+
+		controlPoint.circle.set({ left: newX, top: newY });
+		controlPoint.circle.setCoords();
+
+		if (controlPoint.pointIndex >= 0 && controlPoint.pointIndex <= 3) {
+			this.updateFromCorner(controlPoint, newX, newY);
+		} else if (controlPoint.pointIndex >= 8 && controlPoint.pointIndex <= 11) {
+			this.updateFromEdge(controlPoint, newX, newY);
+		} else if (controlPoint.pointIndex === 12) {
+			this.updateFromRotation(controlPoint, newX, newY);
+		}
+	}
+
+	private updateFromCorner(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const textbox = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) =>
+					obj.id === controlPoint.objectId && obj.type === 'textbox',
+			) as fabric.Textbox | undefined;
+		if (!textbox) return;
+
+		// Maintain aspect ratio like images - diagonal movement only
+		const width = textbox.width || 0;
+		const height = textbox.height || 0;
+		const aspectRatio = width / height;
+		const oppositeIndex = (controlPoint.pointIndex + 2) % 4;
+		const corners = [
+			{ x: textbox.left || 0, y: textbox.top || 0 },
+			{ x: (textbox.left || 0) + width, y: textbox.top || 0 },
+			{ x: (textbox.left || 0) + width, y: (textbox.top || 0) + height },
+			{ x: textbox.left || 0, y: (textbox.top || 0) + height },
+		];
+
+		const anchorCorner = corners[oppositeIndex];
+		const dx = newX - anchorCorner.x;
+		const dy = newY - anchorCorner.y;
+
+		// Determine which dimension constrains us (to maintain aspect ratio)
+		let finalWidth, finalHeight;
+		const projectedWidthAbs = Math.abs(dx);
+		const projectedHeightAbs = Math.abs(dy);
+
+		if (projectedWidthAbs / aspectRatio > projectedHeightAbs) {
+			// Height is the constraint
+			finalHeight = projectedHeightAbs;
+			finalWidth = finalHeight * aspectRatio;
+		} else {
+			// Width is the constraint
+			finalWidth = projectedWidthAbs;
+			finalHeight = finalWidth / aspectRatio;
+		}
+
+		// Ensure minimum size
+		finalWidth = Math.max(50, finalWidth);
+		finalHeight = Math.max(20, finalHeight);
+
+		// Calculate scale factor for font size
+		const scaleFactor = Math.sqrt(
+			(finalWidth * finalHeight) / (width * height),
+		);
+		const newFontSize = Math.max(8, (textbox.fontSize || 16) * scaleFactor);
+
+		// Determine new position based on which quadrant we're dragging from
+		const newLeft = dx >= 0 ? anchorCorner.x : anchorCorner.x - finalWidth;
+		const newTop = dy >= 0 ? anchorCorner.y : anchorCorner.y - finalHeight;
+
+		textbox.set({
+			left: newLeft,
+			top: newTop,
+			width: finalWidth,
+			fontSize: newFontSize,
+		});
+		textbox.initDimensions();
+		textbox.setCoords();
+
+		this.updateControlPoints(controlPoint.objectId, textbox);
+		this.canvas.renderAll();
+	}
+
+	private updateFromEdge(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const textbox = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) =>
+					obj.id === controlPoint.objectId && obj.type === 'textbox',
+			) as fabric.Textbox | undefined;
+		if (!textbox) return;
+
+		const width = textbox.width || 0;
+		const height = textbox.height || 0;
+		const left = textbox.left || 0;
+		const top = textbox.top || 0;
+
+		// Left/right edges: just reflow text
+		if (controlPoint.pointIndex === 9) {
+			// Right edge - just change width
+			textbox.set({ width: Math.max(50, newX - left) });
+			textbox.initDimensions();
+			textbox.setCoords();
+			this.updateControlPoints(controlPoint.objectId, textbox);
+			this.canvas.renderAll();
+		} else if (controlPoint.pointIndex === 11) {
+			// Left edge - just change width
+			const newWidth = Math.max(50, left + width - newX);
+			textbox.set({ left: newX, width: newWidth });
+			textbox.initDimensions();
+			textbox.setCoords();
+			this.updateControlPoints(controlPoint.objectId, textbox);
+			this.canvas.renderAll();
+		} else if (controlPoint.pointIndex === 8) {
+			// Top center - moves top up/down, scales width proportionally
+			// Keep bottom and right edges fixed
+			const aspectRatio = width / height;
+			const bottomEdge = top + height;
+			const rightEdge = left + width;
+			const newHeight = Math.abs(bottomEdge - newY);
+			const newWidth = newHeight * aspectRatio;
+
+			const finalWidth = Math.max(50, newWidth);
+			const finalHeight = Math.max(20, newHeight);
+
+			const scaleFactor = Math.sqrt(
+				(finalWidth * finalHeight) / (width * height),
+			);
+			const newFontSize = Math.max(8, (textbox.fontSize || 16) * scaleFactor);
+
+			// Right edge stays fixed, left edge moves
+			const newLeft = rightEdge - finalWidth;
+			const newTop = newY;
+
+			textbox.set({
+				left: newLeft,
+				top: newTop,
+				width: finalWidth,
+				fontSize: newFontSize,
+			});
+			textbox.initDimensions();
+			textbox.setCoords();
+			this.updateControlPoints(controlPoint.objectId, textbox);
+			this.canvas.renderAll();
+		} else if (controlPoint.pointIndex === 10) {
+			// Bottom center - moves bottom up/down, scales width proportionally
+			// Keep top and left edges fixed
+			const aspectRatio = width / height;
+			const topEdge = top;
+			const leftEdge = left;
+			const newHeight = Math.abs(newY - topEdge);
+			const newWidth = newHeight * aspectRatio;
+
+			const finalWidth = Math.max(50, newWidth);
+			const finalHeight = Math.max(20, newHeight);
+
+			const scaleFactor = Math.sqrt(
+				(finalWidth * finalHeight) / (width * height),
+			);
+			const newFontSize = Math.max(8, (textbox.fontSize || 16) * scaleFactor);
+
+			// Top and left edges stay fixed
+			textbox.set({
+				left: leftEdge,
+				top: topEdge,
+				width: finalWidth,
+				fontSize: newFontSize,
+			});
+			textbox.initDimensions();
+			textbox.setCoords();
+			this.updateControlPoints(controlPoint.objectId, textbox);
+			this.canvas.renderAll();
+		}
+	}
+
+	private updateFromRotation(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const textbox = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) =>
+					obj.id === controlPoint.objectId && obj.type === 'textbox',
+			) as fabric.Textbox | undefined;
+		if (!textbox) return;
+
+		// Get the center point for rotation
+		const width = textbox.width || 0;
+		const height = textbox.height || 0;
+		const left = textbox.left || 0;
+		const top = textbox.top || 0;
+		const centerX = left + width / 2;
+		const centerY = top + height / 2;
+
+		// Calculate angle from center to rotation handle
+		const dx = newX - centerX;
+		const dy = newY - centerY;
+		const angleDeg = (Math.atan2(dy, dx) * 180) / Math.PI + 90;
+
+		// Set angle and update coords
+		textbox.set({ angle: angleDeg });
+		textbox.setCoords();
+		this.updateControlPoints(controlPoint.objectId, textbox);
+		this.canvas.renderAll();
+	}
+}
+
+/**
+ * Control point handler for images
+ */
+export class ImageControlPoints extends BoundingBoxControlPoints {
+	addControlPoints(
+		objectId: string,
+		obj: fabric.Object,
+		visible: boolean = true,
+	): void {
+		const image = obj as fabric.Image;
+		const width = image.width || 0;
+		const height = image.height || 0;
+		const scaleX = image.scaleX || 1;
+		const scaleY = image.scaleY || 1;
+
+		// If image has a clipPath, use the clip dimensions and offset for control points
+		let effectiveWidth = width;
+		let effectiveHeight = height;
+		let clipOffsetX = 0;
+		let clipOffsetY = 0;
+
+		if (image.clipPath && image.clipPath.type === 'rect') {
+			const clipRect = image.clipPath as fabric.Rect;
+			effectiveWidth = clipRect.width || width;
+			effectiveHeight = clipRect.height || height;
+			// The clipPath left/top are relative to the image center
+			clipOffsetX = (clipRect.left || 0) + effectiveWidth / 2;
+			clipOffsetY = (clipRect.top || 0) + effectiveHeight / 2;
+		}
+
+		// Get transformation matrix
+		const matrix = image.calcTransformMatrix();
+
+		// Define corners in local coordinates (unscaled, relative to origin)
+		// Images use center origin, so corners are at ±width/2, ±height/2
+		// When clipped, we need to offset by the clip position
+		const corners = [
+			{
+				x: clipOffsetX - effectiveWidth / 2,
+				y: clipOffsetY - effectiveHeight / 2,
+			}, // Top-left
+			{
+				x: clipOffsetX + effectiveWidth / 2,
+				y: clipOffsetY - effectiveHeight / 2,
+			}, // Top-right
+			{
+				x: clipOffsetX + effectiveWidth / 2,
+				y: clipOffsetY + effectiveHeight / 2,
+			}, // Bottom-right
+			{
+				x: clipOffsetX - effectiveWidth / 2,
+				y: clipOffsetY + effectiveHeight / 2,
+			}, // Bottom-left
+		];
+
+		// Transform to absolute coordinates (this applies scale, rotation, and translation)
+		const absoluteCorners = corners.map((corner) =>
+			fabric.util.transformPoint(new fabric.Point(corner.x, corner.y), matrix),
+		);
+
+		// Create corner control points (indices 0-3)
+		absoluteCorners.forEach((corner, index) => {
+			const controlPointId = `${objectId}-cp-${index}`;
+			const circle = this.createControlPointCircle(
+				corner.x,
+				corner.y,
+				controlPointId,
+				objectId,
+				index,
+				true,
+			);
+			circle.set({ visible });
+			this.canvas.add(circle);
+			this.controlPoints.push({
+				id: controlPointId,
+				circle,
+				objectId,
+				pointIndex: index,
+			});
+		});
+
+		// Create edge midpoint control points (indices 8-11)
+		const edgeMidpoints = [
+			{
+				x: (absoluteCorners[0].x + absoluteCorners[1].x) / 2,
+				y: (absoluteCorners[0].y + absoluteCorners[1].y) / 2,
+				pointIndex: 8,
+			},
+			{
+				x: (absoluteCorners[1].x + absoluteCorners[2].x) / 2,
+				y: (absoluteCorners[1].y + absoluteCorners[2].y) / 2,
+				pointIndex: 9,
+			},
+			{
+				x: (absoluteCorners[2].x + absoluteCorners[3].x) / 2,
+				y: (absoluteCorners[2].y + absoluteCorners[3].y) / 2,
+				pointIndex: 10,
+			},
+			{
+				x: (absoluteCorners[3].x + absoluteCorners[0].x) / 2,
+				y: (absoluteCorners[3].y + absoluteCorners[0].y) / 2,
+				pointIndex: 11,
+			},
+		];
+
+		edgeMidpoints.forEach((midpoint) => {
+			const controlPointId = `${objectId}-cp-${midpoint.pointIndex}`;
+			const circle = this.createControlPointCircle(
+				midpoint.x,
+				midpoint.y,
+				controlPointId,
+				objectId,
+				midpoint.pointIndex,
+				true,
+			);
+			circle.set({ visible });
+			this.canvas.add(circle);
+			this.controlPoints.push({
+				id: controlPointId,
+				circle,
+				objectId,
+				pointIndex: midpoint.pointIndex,
+			});
+		});
+
+		// Create rotation handle (index 12) - floating, zoom-adjusted distance above the top edge in rotated space
+		const topMidpoint = edgeMidpoints[0];
+		const center = image.getCenterPoint();
+		const vectorX = topMidpoint.x - center.x;
+		const vectorY = topMidpoint.y - center.y;
+		const vectorLength = Math.sqrt(vectorX * vectorX + vectorY * vectorY);
+		const normalizedX = vectorX / vectorLength;
+		const normalizedY = vectorY / vectorLength;
+		const rotationDistance = this.getRotationHandleDistance();
+		const rotationX =
+			center.x + normalizedX * (vectorLength + rotationDistance);
+		const rotationY =
+			center.y + normalizedY * (vectorLength + rotationDistance);
+		const rotationControlPointId = `${objectId}-cp-12`;
+		const rotationCircle = this.createControlPointCircle(
+			rotationX,
+			rotationY,
+			rotationControlPointId,
+			objectId,
+			12,
+			true,
+		);
+		rotationCircle.set({ visible, hoverCursor: 'crosshair' });
+		this.canvas.add(rotationCircle);
+		this.controlPoints.push({
+			id: rotationControlPointId,
+			circle: rotationCircle,
+			objectId,
+			pointIndex: 12,
+		});
+
+		// Create border lines
+		const zoom = this.canvas.getZoom();
+		const scale = 1 / zoom;
+
+		const edges = [
+			{ start: 0, end: 1 },
+			{ start: 1, end: 2 },
+			{ start: 2, end: 3 },
+			{ start: 3, end: 0 },
+		];
+
+		edges.forEach(({ start, end }, index) => {
+			const edgeId = `${objectId}-edge-${index}`;
+			const edgeLine = new fabric.Line(
+				[
+					absoluteCorners[start].x,
+					absoluteCorners[start].y,
+					absoluteCorners[end].x,
+					absoluteCorners[end].y,
+				],
+				{
+					stroke: 'oklch(0.8 0.05 39.0427)',
+					strokeWidth: 1.5 * scale,
+					selectable: false,
+					evented: false,
+					excludeFromExport: true,
+					visible,
+				},
+			);
+			(edgeLine as any).id = edgeId;
+			(edgeLine as any).linkedObjectId = objectId;
+			this.canvas.add(edgeLine);
+			this.edgeLines.set(edgeId, edgeLine);
+		});
+
+		this.bringControlPointsToFront();
+		this.canvas.renderAll();
+	}
+
+	removeControlPoints(objectId: string): void {
+		const pointsToRemove = this.controlPoints.filter(
+			(cp) => cp.objectId === objectId,
+		);
+		pointsToRemove.forEach((cp) => this.canvas.remove(cp.circle));
+		this.controlPoints = this.controlPoints.filter(
+			(cp) => cp.objectId !== objectId,
+		);
+
+		const edgeLinesToRemove: string[] = [];
+		this.edgeLines.forEach((line, id) => {
+			if ((line as any).linkedObjectId === objectId) {
+				this.canvas.remove(line);
+				edgeLinesToRemove.push(id);
+			}
+		});
+		edgeLinesToRemove.forEach((id) => this.edgeLines.delete(id));
+		this.canvas.renderAll();
+	}
+
+	hideControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => cp.circle.set({ visible: false }));
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId)
+				line.set({ visible: false });
+		});
+		this.canvas.renderAll();
+	}
+
+	showControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => cp.circle.set({ visible: true }));
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId)
+				line.set({ visible: true });
+		});
+		this.canvas.renderAll();
+	}
+
+	updateControlPoints(objectId: string, obj: fabric.Object): void {
+		const image = obj as fabric.Image;
+		const controlPoints = this.getControlPointsForObject(objectId);
+		if (controlPoints.length === 0) return;
+
+		const width = image.width || 0;
+		const height = image.height || 0;
+
+		// If image has a clipPath, use the clip dimensions and offset for control points
+		let effectiveWidth = width;
+		let effectiveHeight = height;
+		let clipOffsetX = 0;
+		let clipOffsetY = 0;
+
+		if (image.clipPath && image.clipPath.type === 'rect') {
+			const clipRect = image.clipPath as fabric.Rect;
+			effectiveWidth = clipRect.width || width;
+			effectiveHeight = clipRect.height || height;
+			// The clipPath left/top are relative to the image center
+			clipOffsetX = (clipRect.left || 0) + effectiveWidth / 2;
+			clipOffsetY = (clipRect.top || 0) + effectiveHeight / 2;
+		}
+
+		const matrix = image.calcTransformMatrix();
+
+		// Define corners in local coordinates (unscaled, relative to center origin)
+		// When clipped, we need to offset by the clip position
+		const corners = [
+			{
+				x: clipOffsetX - effectiveWidth / 2,
+				y: clipOffsetY - effectiveHeight / 2,
+			},
+			{
+				x: clipOffsetX + effectiveWidth / 2,
+				y: clipOffsetY - effectiveHeight / 2,
+			},
+			{
+				x: clipOffsetX + effectiveWidth / 2,
+				y: clipOffsetY + effectiveHeight / 2,
+			},
+			{
+				x: clipOffsetX - effectiveWidth / 2,
+				y: clipOffsetY + effectiveHeight / 2,
+			},
+		];
+
+		// Transform to absolute coordinates (matrix handles scale, rotation, translation)
+		const absoluteCorners = corners.map((corner) =>
+			fabric.util.transformPoint(new fabric.Point(corner.x, corner.y), matrix),
+		);
+
+		// Update corners
+		controlPoints.forEach((cp) => {
+			if (cp.pointIndex >= 0 && cp.pointIndex <= 3) {
+				cp.circle.set({
+					left: absoluteCorners[cp.pointIndex].x,
+					top: absoluteCorners[cp.pointIndex].y,
+				});
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update edge midpoints
+		const edgeMidpoints = [
+			{
+				x: (absoluteCorners[0].x + absoluteCorners[1].x) / 2,
+				y: (absoluteCorners[0].y + absoluteCorners[1].y) / 2,
+				pointIndex: 8,
+			},
+			{
+				x: (absoluteCorners[1].x + absoluteCorners[2].x) / 2,
+				y: (absoluteCorners[1].y + absoluteCorners[2].y) / 2,
+				pointIndex: 9,
+			},
+			{
+				x: (absoluteCorners[2].x + absoluteCorners[3].x) / 2,
+				y: (absoluteCorners[2].y + absoluteCorners[3].y) / 2,
+				pointIndex: 10,
+			},
+			{
+				x: (absoluteCorners[3].x + absoluteCorners[0].x) / 2,
+				y: (absoluteCorners[3].y + absoluteCorners[0].y) / 2,
+				pointIndex: 11,
+			},
+		];
+
+		edgeMidpoints.forEach((midpoint) => {
+			const cp = controlPoints.find(
+				(cp) => cp.pointIndex === midpoint.pointIndex,
+			);
+			if (cp) {
+				cp.circle.set({ left: midpoint.x, top: midpoint.y });
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update rotation handle
+		const topMidpoint = edgeMidpoints[0];
+		const rotationCp = controlPoints.find((cp) => cp.pointIndex === 12);
+		if (rotationCp) {
+			const center = image.getCenterPoint();
+			const vectorX = topMidpoint.x - center.x;
+			const vectorY = topMidpoint.y - center.y;
+			const vectorLength = Math.sqrt(vectorX * vectorX + vectorY * vectorY);
+			const normalizedX = vectorX / vectorLength;
+			const normalizedY = vectorY / vectorLength;
+			rotationCp.circle.set({
+				left: center.x + normalizedX * (vectorLength + 30),
+				top: center.y + normalizedY * (vectorLength + 30),
+			});
+			rotationCp.circle.setCoords();
+		}
+
+		// Update edge lines
+		const edges = [
+			{ start: 0, end: 1 },
+			{ start: 1, end: 2 },
+			{ start: 2, end: 3 },
+			{ start: 3, end: 0 },
+		];
+
+		edges.forEach(({ start, end }, index) => {
+			const edgeId = `${objectId}-edge-${index}`;
+			const edgeLine = this.edgeLines.get(edgeId);
+			if (edgeLine) {
+				edgeLine.set({
+					x1: absoluteCorners[start].x,
+					y1: absoluteCorners[start].y,
+					x2: absoluteCorners[end].x,
+					y2: absoluteCorners[end].y,
+				});
+				edgeLine.setCoords();
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	updateObjectFromControlPoint(
+		controlPointId: string,
+		newX: number,
+		newY: number,
+	): void {
+		const controlPoint = this.controlPoints.find(
+			(cp) => cp.id === controlPointId,
+		);
+		if (!controlPoint) return;
+
+		controlPoint.circle.set({ left: newX, top: newY });
+		controlPoint.circle.setCoords();
+
+		if (controlPoint.pointIndex >= 0 && controlPoint.pointIndex <= 3) {
+			this.updateFromCorner(controlPoint, newX, newY);
+		} else if (controlPoint.pointIndex >= 8 && controlPoint.pointIndex <= 11) {
+			this.updateFromEdge(controlPoint, newX, newY);
+		} else if (controlPoint.pointIndex === 12) {
+			this.updateFromRotation(controlPoint, newX, newY);
+		}
+	}
+
+	private updateFromCorner(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const image = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) => obj.id === controlPoint.objectId && obj.type === 'image',
+			) as fabric.Image | undefined;
+		if (!image) return;
+
+		// Maintain aspect ratio for corners
+		const originalWidth = image.width || 0;
+		const originalHeight = image.height || 0;
+		const aspectRatio = originalWidth / originalHeight;
+		const angle = image.angle || 0;
+		const angleRad = (angle * Math.PI) / 180;
+
+		const oppositeIndex = (controlPoint.pointIndex + 2) % 4;
+		const anchorCornerCP = this.getControlPointsForObject(
+			controlPoint.objectId,
+		).find((cp) => cp.pointIndex === oppositeIndex);
+
+		// Get the anchor corner position from the control point
+		const anchorPosition = anchorCornerCP
+			? anchorCornerCP.circle.getCenterPoint()
+			: image.getCenterPoint();
+
+		// Calculate the vector from anchor to mouse
+		const dx = newX - anchorPosition.x;
+		const dy = newY - anchorPosition.y;
+
+		// Project this vector onto the rotated width and height axes
+		// Width axis (rotated horizontal)
+		const widthAxisX = Math.cos(angleRad);
+		const widthAxisY = Math.sin(angleRad);
+		const widthProjection = dx * widthAxisX + dy * widthAxisY;
+
+		// Height axis (rotated vertical)
+		const heightAxisX = -Math.sin(angleRad);
+		const heightAxisY = Math.cos(angleRad);
+		const heightProjection = dx * heightAxisX + dy * heightAxisY;
+
+		// Determine which dimension constrains us (to maintain aspect ratio)
+		// Use the dimension that would make the smaller scaled image
+		let finalWidth, finalHeight;
+		const projectedWidthAbs = Math.abs(widthProjection);
+		const projectedHeightAbs = Math.abs(heightProjection);
+
+		if (projectedWidthAbs / aspectRatio > projectedHeightAbs) {
+			// Height is the constraint
+			finalHeight = projectedHeightAbs;
+			finalWidth = finalHeight * aspectRatio;
+		} else {
+			// Width is the constraint
+			finalWidth = projectedWidthAbs;
+			finalHeight = finalWidth / aspectRatio;
+		}
+
+		// Ensure minimum size
+		const minSize = 20;
+		finalWidth = Math.max(minSize, finalWidth);
+		finalHeight = Math.max(minSize / aspectRatio, finalHeight);
+
+		// Determine the sign of the projections to know which direction we're dragging
+		const widthSign = widthProjection >= 0 ? 1 : -1;
+		const heightSign = heightProjection >= 0 ? 1 : -1;
+
+		// Calculate new center - move along the rotated axes
+		const newCenterX =
+			anchorPosition.x +
+			(widthSign * finalWidth * widthAxisX) / 2 +
+			(heightSign * finalHeight * heightAxisX) / 2;
+		const newCenterY =
+			anchorPosition.y +
+			(widthSign * finalWidth * widthAxisY) / 2 +
+			(heightSign * finalHeight * heightAxisY) / 2;
+
+		// Calculate new scale
+		const newScaleX = finalWidth / originalWidth;
+		const newScaleY = finalHeight / originalHeight;
+
+		image.set({
+			left: newCenterX,
+			top: newCenterY,
+			scaleX: newScaleX,
+			scaleY: newScaleY,
+		});
+		image.setCoords();
+
+		this.updateControlPoints(controlPoint.objectId, image);
+		this.canvas.renderAll();
+	}
+
+	private updateFromEdge(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const image = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) => obj.id === controlPoint.objectId && obj.type === 'image',
+			) as fabric.Image | undefined;
+		if (!image) return;
+
+		const originalWidth = image.width || 0;
+		const originalHeight = image.height || 0;
+		const angle = image.angle || 0;
+		const center = image.getCenterPoint();
+		const angleRad = (angle * Math.PI) / 180;
+
+		const newPoint = new fabric.Point(newX, newY);
+
+		// Determine which dimension to change and how to move the center
+		let newWidth = (image.width || 0) * (image.scaleX || 1);
+		let newHeight = (image.height || 0) * (image.scaleY || 1);
+		let newCenterX = center.x;
+		let newCenterY = center.y;
+
+		switch (controlPoint.pointIndex) {
+			case 8: // Top edge
+			case 10: {
+				// Bottom edge
+				// Direction perpendicular to the edge (pointing inward/outward)
+				const perpX = -Math.sin(angleRad);
+				const perpY = Math.cos(angleRad);
+				// For top edge (8), perpendicular points up (negative in local coords)
+				// For bottom edge (10), perpendicular points down (positive in local coords)
+				const edgeSign = controlPoint.pointIndex === 8 ? -1 : 1;
+				// Calculate where the opposite edge currently is
+				const oppositeEdgeOffset = (newHeight / 2) * -edgeSign;
+				const oppositeEdgeX = center.x + perpX * oppositeEdgeOffset;
+				const oppositeEdgeY = center.y + perpY * oppositeEdgeOffset;
+				// Distance from new mouse position to opposite edge (in perpendicular direction)
+				const distanceFromOpposite =
+					(newPoint.x - oppositeEdgeX) * perpX +
+					(newPoint.y - oppositeEdgeY) * perpY;
+				// New height is this distance
+				newHeight = Math.max(20, Math.abs(distanceFromOpposite));
+				// New center is halfway between mouse and opposite edge
+				newCenterX = oppositeEdgeX + (perpX * distanceFromOpposite) / 2;
+				newCenterY = oppositeEdgeY + (perpY * distanceFromOpposite) / 2;
+				break;
+			}
+			case 9: // Right edge
+			case 11: {
+				// Left edge
+				// Direction perpendicular to the edge (pointing inward/outward)
+				const perpX = Math.cos(angleRad);
+				const perpY = Math.sin(angleRad);
+				// For left edge (11), perpendicular points left (negative in local coords)
+				// For right edge (9), perpendicular points right (positive in local coords)
+				const edgeSign = controlPoint.pointIndex === 11 ? -1 : 1;
+				// Calculate where the opposite edge currently is
+				const oppositeEdgeOffset = (newWidth / 2) * -edgeSign;
+				const oppositeEdgeX = center.x + perpX * oppositeEdgeOffset;
+				const oppositeEdgeY = center.y + perpY * oppositeEdgeOffset;
+				// Distance from new mouse position to opposite edge (in perpendicular direction)
+				const distanceFromOpposite =
+					(newPoint.x - oppositeEdgeX) * perpX +
+					(newPoint.y - oppositeEdgeY) * perpY;
+				// New width is this distance
+				newWidth = Math.max(20, Math.abs(distanceFromOpposite));
+				// New center is halfway between mouse and opposite edge
+				newCenterX = oppositeEdgeX + (perpX * distanceFromOpposite) / 2;
+				newCenterY = oppositeEdgeY + (perpY * distanceFromOpposite) / 2;
+				break;
+			}
+		}
+
+		// Calculate new scale
+		const newScaleX = newWidth / originalWidth;
+		const newScaleY = newHeight / originalHeight;
+
+		image.set({
+			left: newCenterX,
+			top: newCenterY,
+			scaleX: newScaleX,
+			scaleY: newScaleY,
+		});
+		image.setCoords();
+
+		this.updateControlPoints(controlPoint.objectId, image);
+		this.canvas.renderAll();
+	}
+
+	private updateFromRotation(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const image = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) => obj.id === controlPoint.objectId && obj.type === 'image',
+			) as fabric.Image | undefined;
+		if (!image) return;
+
+		const center = image.getCenterPoint();
+		const dx = newX - center.x;
+		const dy = newY - center.y;
+		const angleDeg = (Math.atan2(dy, dx) * 180) / Math.PI + 90;
+
+		image.set({ angle: angleDeg });
+		image.setCoords();
+		this.updateControlPoints(controlPoint.objectId, image);
+		this.canvas.renderAll();
+	}
+}
+
+/**
+ * Control point handler for paths (freehand drawings)
+ */
+export class PathControlPoints extends BoundingBoxControlPoints {
+	addControlPoints(
+		objectId: string,
+		obj: fabric.Object,
+		visible: boolean = true,
+	): void {
+		// DISABLED: All control points for brush/path objects due to bugs
+		/*
+const path = obj as fabric.Path
+const bounds = path.getBoundingRect()
+
+// Use bounding rect corners
+const corners = [
+{ x: bounds.left, y: bounds.top },
+{ x: bounds.left + bounds.width, y: bounds.top },
+{ x: bounds.left + bounds.width, y: bounds.top + bounds.height },
+{ x: bounds.left, y: bounds.top + bounds.height }
+]
+
+// Create corner control points
+corners.forEach((corner, index) => {
+const controlPointId = `${objectId}-cp-${index}`
+const circle = this.createControlPointCircle(
+corner.x,
+corner.y,
+controlPointId,
+objectId,
+index,
+true
+)
+circle.set({ visible })
+this.canvas.add(circle)
+this.controlPoints.push({ id: controlPointId, circle, objectId, pointIndex: index })
+})
+
+// Create edge midpoints
+const edgeMidpoints = [
+{ x: (corners[0].x + corners[1].x) / 2, y: (corners[0].y + corners[1].y) / 2, pointIndex: 8 },
+{ x: (corners[1].x + corners[2].x) / 2, y: (corners[1].y + corners[2].y) / 2, pointIndex: 9 },
+{
+x: (corners[2].x + corners[3].x) / 2,
+y: (corners[2].y + corners[3].y) / 2,
+pointIndex: 10
+},
+{ x: (corners[3].x + corners[0].x) / 2, y: (corners[3].y + corners[0].y) / 2, pointIndex: 11 }
+]
+
+edgeMidpoints.forEach((midpoint) => {
+const controlPointId = `${objectId}-cp-${midpoint.pointIndex}`
+const circle = this.createControlPointCircle(
+midpoint.x,
+midpoint.y,
+controlPointId,
+objectId,
+midpoint.pointIndex,
+true
+)
+circle.set({ visible })
+this.canvas.add(circle)
+this.controlPoints.push({
+id: controlPointId,
+circle,
+objectId,
+pointIndex: midpoint.pointIndex
+})
+})
+
+// Create rotation handle with zoom-adjusted distance
+const topMidpoint = edgeMidpoints[0]
+const center = path.getCenterPoint()
+const vectorX = topMidpoint.x - center.x
+const vectorY = topMidpoint.y - center.y
+const vectorLength = Math.sqrt(vectorX * vectorX + vectorY * vectorY)
+const normalizedX = vectorX / vectorLength
+const normalizedY = vectorY / vectorLength
+const rotationDistance = this.getRotationHandleDistance()
+const rotationX = center.x + normalizedX * (vectorLength + rotationDistance)
+const rotationY = center.y + normalizedY * (vectorLength + rotationDistance)
+const rotationControlPointId = `${objectId}-cp-12`
+const rotationCircle = this.createControlPointCircle(
+rotationX,
+rotationY,
+rotationControlPointId,
+objectId,
+12,
+true
+)
+rotationCircle.set({ visible, hoverCursor: 'crosshair' })
+this.canvas.add(rotationCircle)
+this.controlPoints.push({
+id: rotationControlPointId,
+circle: rotationCircle,
+objectId,
+pointIndex: 12
+})
+
+// Create border lines
+const zoom = this.canvas.getZoom()
+const scale = 1 / zoom
+
+const edges = [
+{ start: 0, end: 1 },
+{ start: 1, end: 2 },
+{ start: 2, end: 3 },
+{ start: 3, end: 0 }
+]
+
+edges.forEach(({ start, end }, index) => {
+const edgeId = `${objectId}-edge-${index}`
+const edgeLine = new fabric.Line(
+[corners[start].x, corners[start].y, corners[end].x, corners[end].y],
+{
+stroke: 'oklch(0.8 0.05 39.0427)',
+strokeWidth: 1.5 * scale,
+selectable: false,
+evented: false,
+excludeFromExport: true,
+visible
+}
+)
+;(edgeLine as any).id = edgeId
+;(edgeLine as any).linkedObjectId = objectId
+this.canvas.add(edgeLine)
+this.edgeLines.set(edgeId, edgeLine)
+})
+
+this.bringControlPointsToFront()
+this.canvas.renderAll()
+*/
+	}
+
+	removeControlPoints(objectId: string): void {
+		const pointsToRemove = this.controlPoints.filter(
+			(cp) => cp.objectId === objectId,
+		);
+		pointsToRemove.forEach((cp) => this.canvas.remove(cp.circle));
+		this.controlPoints = this.controlPoints.filter(
+			(cp) => cp.objectId !== objectId,
+		);
+
+		const edgeLinesToRemove: string[] = [];
+		this.edgeLines.forEach((line, id) => {
+			if ((line as any).linkedObjectId === objectId) {
+				this.canvas.remove(line);
+				edgeLinesToRemove.push(id);
+			}
+		});
+		edgeLinesToRemove.forEach((id) => this.edgeLines.delete(id));
+		this.canvas.renderAll();
+	}
+
+	hideControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => cp.circle.set({ visible: false }));
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId)
+				line.set({ visible: false });
+		});
+		this.canvas.renderAll();
+	}
+
+	showControlPoints(objectId: string): void {
+		const points = this.controlPoints.filter((cp) => cp.objectId === objectId);
+		points.forEach((cp) => cp.circle.set({ visible: true }));
+		this.edgeLines.forEach((line) => {
+			if ((line as any).linkedObjectId === objectId)
+				line.set({ visible: true });
+		});
+		this.canvas.renderAll();
+	}
+
+	updateControlPoints(objectId: string, obj: fabric.Object): void {
+		const path = obj as fabric.Path;
+		const controlPoints = this.getControlPointsForObject(objectId);
+		if (controlPoints.length === 0) return;
+
+		const bounds = path.getBoundingRect();
+		const corners = [
+			{ x: bounds.left, y: bounds.top },
+			{ x: bounds.left + bounds.width, y: bounds.top },
+			{ x: bounds.left + bounds.width, y: bounds.top + bounds.height },
+			{ x: bounds.left, y: bounds.top + bounds.height },
+		];
+
+		// Update corners
+		controlPoints.forEach((cp) => {
+			if (cp.pointIndex >= 0 && cp.pointIndex <= 3) {
+				cp.circle.set({
+					left: corners[cp.pointIndex].x,
+					top: corners[cp.pointIndex].y,
+				});
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update edge midpoints
+		const edgeMidpoints = [
+			{
+				x: (corners[0].x + corners[1].x) / 2,
+				y: (corners[0].y + corners[1].y) / 2,
+				pointIndex: 8,
+			},
+			{
+				x: (corners[1].x + corners[2].x) / 2,
+				y: (corners[1].y + corners[2].y) / 2,
+				pointIndex: 9,
+			},
+			{
+				x: (corners[2].x + corners[3].x) / 2,
+				y: (corners[2].y + corners[3].y) / 2,
+				pointIndex: 10,
+			},
+			{
+				x: (corners[3].x + corners[0].x) / 2,
+				y: (corners[3].y + corners[0].y) / 2,
+				pointIndex: 11,
+			},
+		];
+
+		edgeMidpoints.forEach((midpoint) => {
+			const cp = controlPoints.find(
+				(cp) => cp.pointIndex === midpoint.pointIndex,
+			);
+			if (cp) {
+				cp.circle.set({ left: midpoint.x, top: midpoint.y });
+				cp.circle.setCoords();
+			}
+		});
+
+		// Update rotation handle with zoom-adjusted distance
+		const topMidpoint = edgeMidpoints[0];
+		const rotationCp = controlPoints.find((cp) => cp.pointIndex === 12);
+		if (rotationCp) {
+			const center = path.getCenterPoint();
+			const vectorX = topMidpoint.x - center.x;
+			const vectorY = topMidpoint.y - center.y;
+			const vectorLength = Math.sqrt(vectorX * vectorX + vectorY * vectorY);
+			const normalizedX = vectorX / vectorLength;
+			const normalizedY = vectorY / vectorLength;
+			const rotationDistance = this.getRotationHandleDistance();
+			rotationCp.circle.set({
+				left: center.x + normalizedX * (vectorLength + rotationDistance),
+				top: center.y + normalizedY * (vectorLength + rotationDistance),
+			});
+			rotationCp.circle.setCoords();
+		}
+
+		// Update edge lines
+		const edges = [
+			{ start: 0, end: 1 },
+			{ start: 1, end: 2 },
+			{ start: 2, end: 3 },
+			{ start: 3, end: 0 },
+		];
+
+		edges.forEach(({ start, end }, index) => {
+			const edgeId = `${objectId}-edge-${index}`;
+			const edgeLine = this.edgeLines.get(edgeId);
+			if (edgeLine) {
+				edgeLine.set({
+					x1: corners[start].x,
+					y1: corners[start].y,
+					x2: corners[end].x,
+					y2: corners[end].y,
+				});
+				edgeLine.setCoords();
+			}
+		});
+
+		this.canvas.renderAll();
+	}
+
+	updateObjectFromControlPoint(
+		controlPointId: string,
+		newX: number,
+		newY: number,
+	): void {
+		const controlPoint = this.controlPoints.find(
+			(cp) => cp.id === controlPointId,
+		);
+		if (!controlPoint) return;
+
+		controlPoint.circle.set({ left: newX, top: newY });
+		controlPoint.circle.setCoords();
+
+		if (controlPoint.pointIndex >= 0 && controlPoint.pointIndex <= 3) {
+			this.updateFromCorner(controlPoint, newX, newY);
+		} else if (controlPoint.pointIndex >= 8 && controlPoint.pointIndex <= 11) {
+			this.updateFromEdge(controlPoint, newX, newY);
+		} else if (controlPoint.pointIndex === 12) {
+			this.updateFromRotation(controlPoint, newX, newY);
+		}
+	}
+
+	private updateFromCorner(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const path = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) => obj.id === controlPoint.objectId && obj.type === 'path',
+			) as fabric.Path | undefined;
+		if (!path) return;
+
+		// Scale path around opposite corner
+		const bounds = path.getBoundingRect();
+		const oppositeIndex = (controlPoint.pointIndex + 2) % 4;
+		const corners = [
+			{ x: bounds.left, y: bounds.top },
+			{ x: bounds.left + bounds.width, y: bounds.top },
+			{ x: bounds.left + bounds.width, y: bounds.top + bounds.height },
+			{ x: bounds.left, y: bounds.top + bounds.height },
+		];
+
+		const anchorCorner = corners[oppositeIndex];
+		const newWidth = Math.abs(newX - anchorCorner.x);
+		const newHeight = Math.abs(newY - anchorCorner.y);
+		const scaleX = newWidth / bounds.width;
+		const scaleY = newHeight / bounds.height;
+
+		path.set({
+			scaleX: (path.scaleX || 1) * scaleX,
+			scaleY: (path.scaleY || 1) * scaleY,
+			left: (newX + anchorCorner.x) / 2,
+			top: (newY + anchorCorner.y) / 2,
+		});
+		path.setCoords();
+
+		this.updateControlPoints(controlPoint.objectId, path);
+		this.canvas.renderAll();
+	}
+
+	private updateFromEdge(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const path = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) => obj.id === controlPoint.objectId && obj.type === 'path',
+			) as fabric.Path | undefined;
+		if (!path) return;
+
+		// Scale path from edge
+		const bounds = path.getBoundingRect();
+		const center = path.getCenterPoint();
+
+		switch (controlPoint.pointIndex) {
+			case 8: // Top
+			case 10: {
+				// Bottom
+				const newHeight = Math.abs(newY - center.y) * 2;
+				const scaleY = newHeight / bounds.height;
+				path.set({ scaleY: (path.scaleY || 1) * scaleY });
+				break;
+			}
+			case 9: // Right
+			case 11: {
+				// Left
+				const newWidth = Math.abs(newX - center.x) * 2;
+				const scaleX = newWidth / bounds.width;
+				path.set({ scaleX: (path.scaleX || 1) * scaleX });
+				break;
+			}
+		}
+
+		path.setCoords();
+		this.updateControlPoints(controlPoint.objectId, path);
+		this.canvas.renderAll();
+	}
+
+	private updateFromRotation(
+		controlPoint: ControlPoint,
+		newX: number,
+		newY: number,
+	): void {
+		const path = this.canvas
+			.getObjects()
+			.find(
+				(obj: any) => obj.id === controlPoint.objectId && obj.type === 'path',
+			) as fabric.Path | undefined;
+		if (!path) return;
+
+		const center = path.getCenterPoint();
+		const dx = newX - center.x;
+		const dy = newY - center.y;
+		const angleDeg = (Math.atan2(dy, dx) * 180) / Math.PI + 90;
+
+		path.set({ angle: angleDeg });
+		path.setCoords();
+		this.updateControlPoints(controlPoint.objectId, path);
+		this.canvas.renderAll();
+	}
+}
+
+/**
+ * Crop overlay manager for image cropping
+ * Creates a darkened overlay with crop handles
+ */
+export class CropOverlay {
+	private canvas: fabric.Canvas;
+	private overlayGroup: fabric.Group | null = null;
+	private cropRect: fabric.Rect | null = null;
+	private handles: fabric.Circle[] = [];
+	private imageId: string | null = null;
+	private originalImage: fabric.Image | null = null;
+	private cropBounds: {
+		left: number;
+		top: number;
+		width: number;
+		height: number;
+	} | null = null;
+	private isDragging = false;
+	private dragStartPoint: { x: number; y: number } | null = null;
+	private activeHandle: number = -1; // -1 = none, 0-3 = corners, 4-7 = edges
+	private onCropChange?: (bounds: {
+		left: number;
+		top: number;
+		width: number;
+		height: number;
+	}) => void;
+
+	constructor(canvas: fabric.Canvas) {
+		this.canvas = canvas;
+	}
+
+	/**
+	 * Start crop mode for an image
+	 */
+	startCrop(
+		image: fabric.Image,
+		onCropChange?: (bounds: {
+			left: number;
+			top: number;
+			width: number;
+			height: number;
+		}) => void,
+	): void {
+		this.imageId = (image as any).id;
+		this.originalImage = image;
+		this.onCropChange = onCropChange;
+
+		// Get the image's current visible bounds
+		const width = (image.width || 0) * (image.scaleX || 1);
+		const height = (image.height || 0) * (image.scaleY || 1);
+		const center = image.getCenterPoint();
+
+		// Initialize crop bounds to full image
+		this.cropBounds = {
+			left: center.x - width / 2,
+			top: center.y - height / 2,
+			width: width,
+			height: height,
+		};
+
+		// Make image non-selectable during crop
+		image.selectable = false;
+		image.evented = false;
+
+		this.createOverlay();
+		this.canvas.renderAll();
+	}
+
+	/**
+	 * Create the crop overlay and handles
+	 */
+	private createOverlay(): void {
+		if (!this.cropBounds || !this.originalImage) return;
+
+		const zoom = this.canvas.getZoom();
+		const scale = 1 / zoom;
+
+		// Create the crop rectangle (the visible area)
+		this.cropRect = new fabric.Rect({
+			left: this.cropBounds.left,
+			top: this.cropBounds.top,
+			width: this.cropBounds.width,
+			height: this.cropBounds.height,
+			fill: 'transparent',
+			stroke: '#ffffff',
+			strokeWidth: 2 * scale,
+			strokeDashArray: [5 * scale, 5 * scale],
+			selectable: false,
+			evented: false,
+			excludeFromExport: true,
+		});
+		(this.cropRect as any).isCropElement = true;
+
+		this.canvas.add(this.cropRect);
+
+		// Create dark overlay outside crop area (4 rectangles)
+		this.createDarkOverlay();
+
+		// Create corner handles (0-3)
+		const corners = [
+			{ x: this.cropBounds.left, y: this.cropBounds.top }, // Top-left
+			{
+				x: this.cropBounds.left + this.cropBounds.width,
+				y: this.cropBounds.top,
+			}, // Top-right
+			{
+				x: this.cropBounds.left + this.cropBounds.width,
+				y: this.cropBounds.top + this.cropBounds.height,
+			}, // Bottom-right
+			{
+				x: this.cropBounds.left,
+				y: this.cropBounds.top + this.cropBounds.height,
+			}, // Bottom-left
+		];
+
+		corners.forEach((corner, index) => {
+			const handle = new fabric.Circle({
+				left: corner.x,
+				top: corner.y,
+				radius: 8 * scale,
+				fill: '#ffffff',
+				stroke: '#0066cc',
+				strokeWidth: 2 * scale,
+				originX: 'center',
+				originY: 'center',
+				selectable: true,
+				hasControls: false,
+				hasBorders: false,
+				hoverCursor: this.getCornerCursor(index),
+				excludeFromExport: true,
+			});
+			(handle as any).isCropHandle = true;
+			(handle as any).handleIndex = index;
+			(handle as any).isCropElement = true;
+			this.handles.push(handle);
+			this.canvas.add(handle);
+		});
+
+		// Create edge midpoint handles (4-7)
+		const edgeMidpoints = [
+			{
+				x: this.cropBounds.left + this.cropBounds.width / 2,
+				y: this.cropBounds.top,
+			}, // Top
+			{
+				x: this.cropBounds.left + this.cropBounds.width,
+				y: this.cropBounds.top + this.cropBounds.height / 2,
+			}, // Right
+			{
+				x: this.cropBounds.left + this.cropBounds.width / 2,
+				y: this.cropBounds.top + this.cropBounds.height,
+			}, // Bottom
+			{
+				x: this.cropBounds.left,
+				y: this.cropBounds.top + this.cropBounds.height / 2,
+			}, // Left
+		];
+
+		edgeMidpoints.forEach((point, index) => {
+			const handle = new fabric.Circle({
+				left: point.x,
+				top: point.y,
+				radius: 6 * scale,
+				fill: '#ffffff',
+				stroke: '#0066cc',
+				strokeWidth: 2 * scale,
+				originX: 'center',
+				originY: 'center',
+				selectable: true,
+				hasControls: false,
+				hasBorders: false,
+				hoverCursor: this.getEdgeCursor(index),
+				excludeFromExport: true,
+			});
+			(handle as any).isCropHandle = true;
+			(handle as any).handleIndex = 4 + index;
+			(handle as any).isCropElement = true;
+			this.handles.push(handle);
+			this.canvas.add(handle);
+		});
+
+		// Bring all crop elements to front
+		this.bringToFront();
+	}
+
+	private darkOverlays: Array<fabric.Rect | fabric.Path> = [];
+
+	/**
+	 * Create dark overlay rectangles outside the crop area
+	 */
+	private createDarkOverlay(): void {
+		if (!this.cropBounds || !this.originalImage) return;
+
+		// Remove existing overlays
+		this.darkOverlays.forEach((overlay) => this.canvas.remove(overlay));
+		this.darkOverlays = [];
+
+		// Get canvas dimensions
+		const canvasWidth = this.canvas.getWidth();
+		const canvasHeight = this.canvas.getHeight();
+
+		// Get viewport transform to calculate visible area
+		const vpt = this.canvas.viewportTransform || [1, 0, 0, 1, 0, 0];
+		const zoom = this.canvas.getZoom();
+
+		// Calculate visible area in canvas coordinates
+		const visibleLeft = -vpt[4] / zoom;
+		const visibleTop = -vpt[5] / zoom;
+		const visibleWidth = canvasWidth / zoom;
+		const visibleHeight = canvasHeight / zoom;
+
+		// Expand visible area for safety
+		const padding = 2000;
+		const left = visibleLeft - padding;
+		const top = visibleTop - padding;
+		const right = visibleLeft + visibleWidth + padding;
+		const bottom = visibleTop + visibleHeight + padding;
+
+		const cropLeft = this.cropBounds.left;
+		const cropTop = this.cropBounds.top;
+		const cropRight = this.cropBounds.left + this.cropBounds.width;
+		const cropBottom = this.cropBounds.top + this.cropBounds.height;
+
+		// Create a single large overlay with a hole cut out for the crop area
+		// This avoids the visible horizontal/vertical lines at crop boundaries
+		const overlayPath = `
+M ${left} ${top}
+L ${right} ${top}
+L ${right} ${bottom}
+L ${left} ${bottom}
+Z
+M ${cropLeft} ${cropTop}
+L ${cropLeft} ${cropBottom}
+L ${cropRight} ${cropBottom}
+L ${cropRight} ${cropTop}
+Z
+`;
+
+		const overlay = new fabric.Path(overlayPath, {
+			fill: 'rgba(0, 0, 0, 0.5)',
+			selectable: false,
+			evented: false,
+			excludeFromExport: true,
+			fillRule: 'evenodd', // This creates the hole effect
+		});
+		(overlay as any).isCropElement = true;
+
+		this.darkOverlays = [overlay];
+		this.canvas.add(overlay);
+	}
+
+	private getCornerCursor(index: number): string {
+		const cursors = ['nw-resize', 'ne-resize', 'se-resize', 'sw-resize'];
+		return cursors[index] || 'pointer';
+	}
+
+	private getEdgeCursor(index: number): string {
+		const cursors = ['n-resize', 'e-resize', 's-resize', 'w-resize'];
+		return cursors[index] || 'pointer';
+	}
+
+	/**
+	 * Update crop bounds when a handle is dragged
+	 */
+	updateFromHandle(handleIndex: number, newX: number, newY: number): void {
+		if (!this.cropBounds || !this.originalImage) return;
+
+		const minSize = 20;
+		let { left, top, width, height } = this.cropBounds;
+
+		// Get image bounds for constraining
+		const imgWidth =
+			(this.originalImage.width || 0) * (this.originalImage.scaleX || 1);
+		const imgHeight =
+			(this.originalImage.height || 0) * (this.originalImage.scaleY || 1);
+		const center = this.originalImage.getCenterPoint();
+		const imgLeft = center.x - imgWidth / 2;
+		const imgTop = center.y - imgHeight / 2;
+		const imgRight = imgLeft + imgWidth;
+		const imgBottom = imgTop + imgHeight;
+
+		// Constrain to image bounds
+		newX = Math.max(imgLeft, Math.min(imgRight, newX));
+		newY = Math.max(imgTop, Math.min(imgBottom, newY));
+
+		switch (handleIndex) {
+			case 0: // Top-left corner
+				const newWidth0 = left + width - newX;
+				const newHeight0 = top + height - newY;
+				if (newWidth0 >= minSize && newHeight0 >= minSize) {
+					width = newWidth0;
+					height = newHeight0;
+					left = newX;
+					top = newY;
+				}
+				break;
+			case 1: // Top-right corner
+				const newWidth1 = newX - left;
+				const newHeight1 = top + height - newY;
+				if (newWidth1 >= minSize && newHeight1 >= minSize) {
+					width = newWidth1;
+					height = newHeight1;
+					top = newY;
+				}
+				break;
+			case 2: // Bottom-right corner
+				const newWidth2 = newX - left;
+				const newHeight2 = newY - top;
+				if (newWidth2 >= minSize && newHeight2 >= minSize) {
+					width = newWidth2;
+					height = newHeight2;
+				}
+				break;
+			case 3: // Bottom-left corner
+				const newWidth3 = left + width - newX;
+				const newHeight3 = newY - top;
+				if (newWidth3 >= minSize && newHeight3 >= minSize) {
+					width = newWidth3;
+					height = newHeight3;
+					left = newX;
+				}
+				break;
+			case 4: // Top edge
+				const newHeight4 = top + height - newY;
+				if (newHeight4 >= minSize) {
+					height = newHeight4;
+					top = newY;
+				}
+				break;
+			case 5: // Right edge
+				const newWidth5 = newX - left;
+				if (newWidth5 >= minSize) {
+					width = newWidth5;
+				}
+				break;
+			case 6: // Bottom edge
+				const newHeight6 = newY - top;
+				if (newHeight6 >= minSize) {
+					height = newHeight6;
+				}
+				break;
+			case 7: // Left edge
+				const newWidth7 = left + width - newX;
+				if (newWidth7 >= minSize) {
+					width = newWidth7;
+					left = newX;
+				}
+				break;
+		}
+
+		this.cropBounds = { left, top, width, height };
+		this.updateOverlay();
+
+		if (this.onCropChange) {
+			this.onCropChange(this.cropBounds);
+		}
+	}
+
+	/**
+	 * Update the overlay and handles to match current crop bounds
+	 */
+	private updateOverlay(): void {
+		if (!this.cropBounds || !this.cropRect) return;
+
+		const zoom = this.canvas.getZoom();
+		const scale = 1 / zoom;
+
+		// Update crop rectangle
+		this.cropRect.set({
+			left: this.cropBounds.left,
+			top: this.cropBounds.top,
+			width: this.cropBounds.width,
+			height: this.cropBounds.height,
+			strokeWidth: 2 * scale,
+			strokeDashArray: [5 * scale, 5 * scale],
+		});
+		this.cropRect.setCoords();
+
+		// Update dark overlays
+		this.createDarkOverlay();
+
+		// Update corner handles
+		const corners = [
+			{ x: this.cropBounds.left, y: this.cropBounds.top },
+			{
+				x: this.cropBounds.left + this.cropBounds.width,
+				y: this.cropBounds.top,
+			},
+			{
+				x: this.cropBounds.left + this.cropBounds.width,
+				y: this.cropBounds.top + this.cropBounds.height,
+			},
+			{
+				x: this.cropBounds.left,
+				y: this.cropBounds.top + this.cropBounds.height,
+			},
+		];
+
+		// Update edge midpoints
+		const edgeMidpoints = [
+			{
+				x: this.cropBounds.left + this.cropBounds.width / 2,
+				y: this.cropBounds.top,
+			},
+			{
+				x: this.cropBounds.left + this.cropBounds.width,
+				y: this.cropBounds.top + this.cropBounds.height / 2,
+			},
+			{
+				x: this.cropBounds.left + this.cropBounds.width / 2,
+				y: this.cropBounds.top + this.cropBounds.height,
+			},
+			{
+				x: this.cropBounds.left,
+				y: this.cropBounds.top + this.cropBounds.height / 2,
+			},
+		];
+
+		this.handles.forEach((handle, index) => {
+			const point = index < 4 ? corners[index] : edgeMidpoints[index - 4];
+			handle.set({
+				left: point.x,
+				top: point.y,
+				radius: (index < 4 ? 8 : 6) * scale,
+				strokeWidth: 2 * scale,
+			});
+			handle.setCoords();
+		});
+
+		this.bringToFront();
+		this.canvas.renderAll();
+	}
+
+	/**
+	 * Check if an object is a crop handle
+	 */
+	isCropHandle(obj: fabric.Object): boolean {
+		return (obj as any).isCropHandle === true;
+	}
+
+	/**
+	 * Check if an object is any crop element
+	 */
+	isCropElement(obj: fabric.Object): boolean {
+		return (obj as any).isCropElement === true;
+	}
+
+	/**
+	 * Get the handle index for a crop handle object
+	 */
+	getHandleIndex(obj: fabric.Object): number {
+		return (obj as any).handleIndex ?? -1;
+	}
+
+	/**
+	 * Bring all crop elements to front
+	 */
+	bringToFront(): void {
+		// Bring dark overlays first
+		this.darkOverlays.forEach((overlay) => {
+			this.canvas.bringObjectToFront(overlay);
+		});
+		// Then crop rect
+		if (this.cropRect) {
+			this.canvas.bringObjectToFront(this.cropRect);
+		}
+		// Finally handles on top
+		this.handles.forEach((handle) => {
+			this.canvas.bringObjectToFront(handle);
+		});
+	}
+
+	/**
+	 * Get current crop bounds
+	 */
+	getCropBounds(): {
+		left: number;
+		top: number;
+		width: number;
+		height: number;
+	} | null {
+		return this.cropBounds;
+	}
+
+	/**
+	 * Get the image being cropped
+	 */
+	getImage(): fabric.Image | null {
+		return this.originalImage;
+	}
+
+	/**
+	 * Get the image ID being cropped
+	 */
+	getImageId(): string | null {
+		return this.imageId;
+	}
+
+	/**
+	 * End crop mode and cleanup
+	 */
+	endCrop(): void {
+		// Remove all crop elements
+		this.handles.forEach((handle) => this.canvas.remove(handle));
+		this.handles = [];
+
+		this.darkOverlays.forEach((overlay) => this.canvas.remove(overlay));
+		this.darkOverlays = [];
+
+		if (this.cropRect) {
+			this.canvas.remove(this.cropRect);
+			this.cropRect = null;
+		}
+
+		// Restore image selectability
+		if (this.originalImage) {
+			this.originalImage.selectable = true;
+			this.originalImage.evented = true;
+		}
+
+		this.imageId = null;
+		this.originalImage = null;
+		this.cropBounds = null;
+		this.onCropChange = undefined;
+
+		this.canvas.renderAll();
+	}
+
+	/**
+	 * Apply the crop to the image using clipPath
+	 */
+	applyCrop(): {
+		success: boolean;
+		imageId: string | null;
+		cropData: any;
+		newImage?: fabric.FabricObject;
+	} {
+		if (!this.originalImage || !this.cropBounds) {
+			return { success: false, imageId: null, cropData: null };
+		}
+
+		const image = this.originalImage;
+		const imageId = this.imageId;
+
+		// Get image properties
+		const center = image.getCenterPoint();
+		const scaleX = image.scaleX || 1;
+		const scaleY = image.scaleY || 1;
+		const angle = image.angle || 0;
+		const opacity = image.opacity || 1;
+		const imgWidth = (image.width || 0) * scaleX;
+		const imgHeight = (image.height || 0) * scaleY;
+		const imgLeft = center.x - imgWidth / 2;
+		const imgTop = center.y - imgHeight / 2;
+
+		// Calculate crop bounds relative to image (in unscaled image coordinates)
+		const cropLeft = (this.cropBounds.left - imgLeft) / scaleX;
+		const cropTop = (this.cropBounds.top - imgTop) / scaleY;
+		const cropWidth = this.cropBounds.width / scaleX;
+		const cropHeight = this.cropBounds.height / scaleY;
+
+		// Crop center in canvas coordinates
+		const newCenterX = this.cropBounds.left + this.cropBounds.width / 2;
+		const newCenterY = this.cropBounds.top + this.cropBounds.height / 2;
+
+		// Calculate the new scale to make the cropped area fill the display bounds
+		const newScaleX = this.cropBounds.width / cropWidth;
+		const newScaleY = this.cropBounds.height / cropHeight;
+
+		// Create a temporary canvas with just the cropped pixels
+		// This ensures the new image's center IS the crop center, so rotation works correctly
+		const imgElement = (image as any)._element as
+			| HTMLImageElement
+			| HTMLCanvasElement;
+		if (imgElement) {
+			const tempCanvas = document.createElement('canvas');
+			tempCanvas.width = Math.round(cropWidth);
+			tempCanvas.height = Math.round(cropHeight);
+			const tempCtx = tempCanvas.getContext('2d');
+			if (tempCtx) {
+				tempCtx.drawImage(
+					imgElement,
+					Math.round(cropLeft),
+					Math.round(cropTop),
+					Math.round(cropWidth),
+					Math.round(cropHeight),
+					0,
+					0,
+					Math.round(cropWidth),
+					Math.round(cropHeight),
+				);
+
+				// Create new fabric Image from the cropped canvas
+				const croppedImg = new fabric.FabricImage(tempCanvas, {
+					left: newCenterX,
+					top: newCenterY,
+					originX: 'center',
+					originY: 'center',
+					scaleX: newScaleX,
+					scaleY: newScaleY,
+					angle: angle,
+					opacity: opacity,
+					hasControls: false,
+					hasBorders: false,
+					selectable: true,
+				});
+				(croppedImg as any).id = imageId;
+
+				// Remove old image and add new cropped image
+				this.canvas.remove(image);
+				this.canvas.add(croppedImg);
+				croppedImg.setCoords();
+
+				this.endCrop();
+
+				return {
+					success: true,
+					imageId,
+					cropData: null, // Will send full object data instead
+					newImage: croppedImg,
+				};
+			}
+		}
+
+		// Fallback: use clipPath approach if canvas extraction fails
+		const clipRect = new fabric.Rect({
+			left: cropLeft - (image.width || 0) / 2,
+			top: cropTop - (image.height || 0) / 2,
+			width: cropWidth,
+			height: cropHeight,
+			absolutePositioned: false,
+		});
+
+		image.clipPath = clipRect;
+		image.set({
+			scaleX: newScaleX,
+			scaleY: newScaleY,
+			left: newCenterX,
+			top: newCenterY,
+		});
+		image.setCoords();
+
+		const cropData = {
+			clipPath: {
+				left: clipRect.left,
+				top: clipRect.top,
+				width: clipRect.width,
+				height: clipRect.height,
+			},
+			scaleX: newScaleX,
+			scaleY: newScaleY,
+			position: { left: newCenterX, top: newCenterY },
+		};
+
+		this.endCrop();
+
+		return { success: true, imageId, cropData };
+	}
+
+	/**
+	 * Cancel crop and restore original state
+	 */
+	cancelCrop(): void {
+		this.endCrop();
+	}
+
+	/**
+	 * Update sizes based on zoom level
+	 */
+	updateSizes(): void {
+		if (!this.cropBounds) return;
+		this.updateOverlay();
+	}
+}
+
+/**
+ * Central manager for all control points on the canvas
+ */
+export class ControlPointManager {
+	private canvas: fabric.Canvas;
+	private handlers: Map<string, ControlPointHandler> = new Map();
+	private lineHandler: LineControlPoints;
+	private rectangleHandler: RectangleControlPoints;
+	private ellipseHandler: EllipseControlPoints;
+	private triangleHandler: TriangleControlPoints;
+	private sendCanvasUpdate?: (data: Record<string, unknown>) => void;
+
+	constructor(
+		canvas: fabric.Canvas,
+		sendCanvasUpdate?: (data: Record<string, unknown>) => void,
+	) {
+		this.canvas = canvas;
+		this.sendCanvasUpdate = sendCanvasUpdate;
+
+		// Initialize handlers for different object types
+		this.lineHandler = new LineControlPoints(canvas);
+		this.handlers.set('polyline', this.lineHandler);
+
+		this.rectangleHandler = new RectangleControlPoints(canvas);
+		this.handlers.set('rect', this.rectangleHandler);
+
+		this.ellipseHandler = new EllipseControlPoints(canvas);
+		this.handlers.set('ellipse', this.ellipseHandler);
+
+		this.triangleHandler = new TriangleControlPoints(canvas);
+		this.handlers.set('triangle', this.triangleHandler);
+
+		// Add new handlers for textbox, image, and path
+		const textboxHandler = new TextboxControlPoints(canvas);
+		this.handlers.set('textbox', textboxHandler);
+
+		const imageHandler = new ImageControlPoints(canvas);
+		this.handlers.set('image', imageHandler);
+
+		const pathHandler = new PathControlPoints(canvas);
+		this.handlers.set('path', pathHandler);
+	}
+
+	/**
+	 * Add control points for an object based on its type
+	 */
+	addControlPoints(
+		objectId: string,
+		obj: fabric.Object,
+		visible: boolean = true,
+	): void {
+		const handler = this.handlers.get(obj.type || '');
+		if (handler) {
+			handler.addControlPoints(objectId, obj, visible);
+		}
+	}
+
+	/**
+	 * Remove control points for an object
+	 */
+	removeControlPoints(objectId: string): void {
+		// Try all handlers since we don't know which one has the control points
+		this.handlers.forEach((handler) => {
+			handler.removeControlPoints(objectId);
+		});
+	}
+
+	/**
+	 * Hide control points for an object
+	 */
+	hideControlPoints(objectId: string): void {
+		this.handlers.forEach((handler) => {
+			handler.hideControlPoints(objectId);
+		});
+	}
+
+	/**
+	 * Show control points for an object
+	 */
+	showControlPoints(objectId: string): void {
+		this.handlers.forEach((handler) => {
+			handler.showControlPoints(objectId);
+		});
+	}
+
+	/**
+	 * Hide all control points across all handlers
+	 */
+	hideAllControlPoints(): void {
+		this.handlers.forEach((handler) => {
+			handler.hideAllControlPoints();
+		});
+	}
+
+	/**
+	 * Update control point positions when an object is moved/transformed
+	 */
+	updateControlPoints(objectId: string, obj: fabric.Object): void {
+		const handler = this.handlers.get(obj.type || '');
+		if (handler) {
+			handler.updateControlPoints(objectId, obj);
+		}
+	}
+
+	/**
+	 * Update the object when a control point is dragged
+	 */
+	updateObjectFromControlPoint(
+		controlPointId: string,
+		newX: number,
+		newY: number,
+		isLive: boolean = true,
+	): void {
+		// Find which handler has this control point
+		for (const handler of this.handlers.values()) {
+			const allPoints = handler.getAllControlPoints();
+			if (allPoints.some((cp) => cp.id === controlPointId)) {
+				handler.updateObjectFromControlPoint(controlPointId, newX, newY);
+
+				// Send canvas update after modifying the object
+				if (this.sendCanvasUpdate) {
+					// Find the modified object and send its update
+					const controlPoint = allPoints.find((cp) => cp.id === controlPointId);
+					if (controlPoint) {
+						const modifiedObj = this.canvas
+							.getObjects()
+							.find((obj: any) => obj.id === controlPoint.objectId);
+						if (modifiedObj && modifiedObj.type === 'image') {
+							// Send image updates (live or final)
+							const image = modifiedObj as fabric.Image;
+							const objData = {
+								id: (image as any).id,
+								type: 'image',
+								left: image.left,
+								top: image.top,
+								scaleX: image.scaleX,
+								scaleY: image.scaleY,
+								angle: image.angle,
+								opacity: image.opacity,
+							};
+							this.sendCanvasUpdate({
+								type: 'modify',
+								object: objData,
+								live: isLive,
+							});
+						} else if (modifiedObj && modifiedObj.type === 'polyline') {
+							// Create a clean serialization with just the essential data
+							// This avoids transformation issues when reconstructing on remote clients
+							const objData = {
+								id: (modifiedObj as any).id,
+								type: 'polyline',
+								points: (modifiedObj as fabric.Polyline).points,
+								stroke: modifiedObj.stroke,
+								strokeWidth: modifiedObj.strokeWidth,
+								strokeDashArray: modifiedObj.strokeDashArray,
+								opacity: modifiedObj.opacity,
+								selectable: true,
+								hasControls: false,
+								hasBorders: false,
+								isControlPointUpdate: true, // Mark this as a control point update
+							};
+							this.sendCanvasUpdate({ type: 'modify', object: objData });
+						} else if (modifiedObj && modifiedObj.type === 'rect') {
+							// Send rectangle updates
+							const rect = modifiedObj as fabric.Rect;
+							const objData = {
+								id: (rect as any).id,
+								type: 'rect',
+								left: rect.left,
+								top: rect.top,
+								width: rect.width,
+								height: rect.height,
+								angle: rect.angle,
+								fill: rect.fill,
+								stroke: rect.stroke,
+								strokeWidth: rect.strokeWidth,
+								strokeDashArray: rect.strokeDashArray,
+								opacity: rect.opacity,
+								originX: 'center',
+								originY: 'center',
+								selectable: true,
+								hasControls: false,
+								hasBorders: false,
+							};
+							this.sendCanvasUpdate({ type: 'modify', object: objData });
+						} else if (modifiedObj && modifiedObj.type === 'ellipse') {
+							// Send ellipse updates
+							const ellipse = modifiedObj as fabric.Ellipse;
+							const objData = {
+								id: (ellipse as any).id,
+								type: 'ellipse',
+								left: ellipse.left,
+								top: ellipse.top,
+								rx: ellipse.rx,
+								ry: ellipse.ry,
+								fill: ellipse.fill,
+								stroke: ellipse.stroke,
+								strokeWidth: ellipse.strokeWidth,
+								strokeDashArray: ellipse.strokeDashArray,
+								opacity: ellipse.opacity,
+								angle: ellipse.angle,
+								originX: 'center',
+								originY: 'center',
+								selectable: true,
+								hasControls: false,
+								hasBorders: false,
+							};
+							this.sendCanvasUpdate({ type: 'modify', object: objData });
+						} else if (modifiedObj && modifiedObj.type === 'triangle') {
+							// Send triangle updates
+							const triangle = modifiedObj as fabric.Triangle;
+							const objData = {
+								id: (triangle as any).id,
+								type: 'triangle',
+								left: triangle.left,
+								top: triangle.top,
+								width: triangle.width,
+								height: triangle.height,
+								fill: triangle.fill,
+								stroke: triangle.stroke,
+								strokeWidth: triangle.strokeWidth,
+								strokeDashArray: triangle.strokeDashArray,
+								opacity: triangle.opacity,
+								angle: triangle.angle,
+								originX: 'center',
+								originY: 'center',
+								selectable: true,
+								hasControls: false,
+								hasBorders: false,
+							};
+							this.sendCanvasUpdate({
+								type: 'modify',
+								object: objData,
+								live: isLive,
+							});
+						} else if (modifiedObj && modifiedObj.type === 'textbox') {
+							// Send textbox updates
+							const textbox = modifiedObj as fabric.Textbox;
+							const objData = {
+								id: (textbox as any).id,
+								type: 'textbox',
+								text: textbox.text,
+								left: textbox.left,
+								top: textbox.top,
+								width: textbox.width,
+								fontSize: textbox.fontSize,
+								fontFamily: textbox.fontFamily,
+								fontWeight: textbox.fontWeight,
+								fill: textbox.fill,
+								textAlign: textbox.textAlign,
+								opacity: textbox.opacity,
+								angle: textbox.angle,
+								selectable: true,
+								hasControls: false,
+								hasBorders: false,
+							};
+							this.sendCanvasUpdate({
+								type: 'modify',
+								object: objData,
+								live: isLive,
+							});
+						}
+					}
+				}
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Check if a given object is a control point
+	 */
+	isControlPoint(obj: fabric.Object): boolean {
+		return (obj as any).isControlPoint === true;
+	}
+
+	/**
+	 * Get the line handler (for backward compatibility and special operations)
+	 */
+	getLineHandler(): LineControlPoints {
+		return this.lineHandler;
+	}
+
+	/**
+	 * Bring all control points to the front
+	 */
+	bringAllControlPointsToFront(): void {
+		this.handlers.forEach((handler) => {
+			handler.bringControlPointsToFront();
+		});
+	}
+
+	/**
+	 * Get all control points across all handlers
+	 */
+	getAllControlPoints(): ControlPoint[] {
+		const allPoints: ControlPoint[] = [];
+		this.handlers.forEach((handler) => {
+			allPoints.push(...handler.getAllControlPoints());
+		});
+		return allPoints;
+	}
+
+	/**
+	 * Update all control point and border sizes based on current zoom level
+	 * Also updates positions to match the current object coordinates
+	 */
+	updateAllControlPointSizes(): void {
+		// First, update sizes
+		this.handlers.forEach((handler) => {
+			handler.updateControlPointSizes();
+		});
+
+		// Then, update positions for all objects with control points
+		// This ensures control points stay aligned with their objects at the new zoom level
+		const processedObjects = new Set<string>();
+		this.handlers.forEach((handler) => {
+			const allPoints = handler.getAllControlPoints();
+			allPoints.forEach((cp) => {
+				if (!processedObjects.has(cp.objectId)) {
+					processedObjects.add(cp.objectId);
+					// Find the object and update its control points
+					const obj = this.canvas
+						.getObjects()
+						.find((o: any) => o.id === cp.objectId);
+					if (obj) {
+						handler.updateControlPoints(cp.objectId, obj);
+					}
+				}
+			});
+		});
+
+		this.canvas.renderAll();
+	}
+}

--- a/src/lib/components/whiteboard/keyboard-shortcuts.ts
+++ b/src/lib/components/whiteboard/keyboard-shortcuts.ts
@@ -1,0 +1,310 @@
+import * as fabric from 'fabric';
+import { v4 as uuidv4 } from 'uuid';
+import type { ControlPointManager } from './control-points';
+
+/**
+ * Clipboard state for copy/paste operations
+ */
+let clipboard: Array<Record<string, unknown>> = [];
+
+/**
+ * Context for keyboard shortcut handlers
+ */
+export interface KeyboardShortcutContext {
+	canvas: fabric.Canvas;
+	sendCanvasUpdate: (data: Record<string, unknown>) => void;
+	controlPointManager?: ControlPointManager;
+	history?: {
+		recordAdd: (
+			objectId: string,
+			objectData: Record<string, unknown>,
+			userId: string,
+		) => void;
+		recordDelete: (
+			objectId: string,
+			objectData: Record<string, unknown>,
+			userId: string,
+		) => void;
+		canUndo: () => boolean;
+		canRedo: () => boolean;
+	};
+	userId?: string;
+	updateHistoryState?: () => void;
+	mousePosition?: { x: number; y: number }; // Current mouse position for paste
+}
+
+/**
+ * Copies the currently selected object(s) to the internal clipboard
+ */
+export function copySelected(ctx: KeyboardShortcutContext): boolean {
+	const activeObjects = ctx.canvas.getActiveObjects();
+	if (activeObjects.length === 0) return false;
+
+	clipboard = [];
+
+	activeObjects.forEach((obj) => {
+		// Skip control points
+		if (ctx.controlPointManager?.isControlPoint(obj)) return;
+
+		const objData =
+			obj.type === 'textbox' ? obj.toObject(['text']) : obj.toObject();
+		// @ts-expect-error - Custom id property
+		objData.id = obj.id;
+		clipboard.push(objData);
+	});
+
+	return clipboard.length > 0;
+}
+
+/**
+ * Pastes objects from the internal clipboard onto the canvas
+ * Objects are centered under the mouse cursor position
+ */
+export async function pasteFromClipboard(
+	ctx: KeyboardShortcutContext,
+): Promise<boolean> {
+	if (clipboard.length === 0) return false;
+
+	const pastedObjects: fabric.Object[] = [];
+	const { util } = await import('fabric');
+
+	// Deselect current selection
+	ctx.canvas.discardActiveObject();
+
+	// Calculate the bounding box center of all clipboard objects
+	let minX = Infinity,
+		minY = Infinity,
+		maxX = -Infinity,
+		maxY = -Infinity;
+	clipboard.forEach((objData) => {
+		const left = typeof objData.left === 'number' ? objData.left : 0;
+		const top = typeof objData.top === 'number' ? objData.top : 0;
+		const width = typeof objData.width === 'number' ? objData.width : 0;
+		const height = typeof objData.height === 'number' ? objData.height : 0;
+		const scaleX = typeof objData.scaleX === 'number' ? objData.scaleX : 1;
+		const scaleY = typeof objData.scaleY === 'number' ? objData.scaleY : 1;
+		minX = Math.min(minX, left);
+		minY = Math.min(minY, top);
+		maxX = Math.max(maxX, left + width * scaleX);
+		maxY = Math.max(maxY, top + height * scaleY);
+	});
+
+	const clipboardCenterX = (minX + maxX) / 2;
+	const clipboardCenterY = (minY + maxY) / 2;
+
+	// Determine target position - use mouse position if available, otherwise center of canvas
+	let targetX: number, targetY: number;
+	if (ctx.mousePosition) {
+		// Convert mouse position to canvas coordinates (accounting for zoom and pan)
+		const pointer = ctx.canvas.getPointer({
+			clientX: ctx.mousePosition.x,
+			clientY: ctx.mousePosition.y,
+		} as MouseEvent);
+		targetX = pointer.x;
+		targetY = pointer.y;
+	} else {
+		// Fall back to center of canvas viewport
+		const vpt = ctx.canvas.viewportTransform || [1, 0, 0, 1, 0, 0];
+		const zoom = ctx.canvas.getZoom();
+		targetX = (ctx.canvas.width! / 2 - vpt[4]) / zoom;
+		targetY = (ctx.canvas.height! / 2 - vpt[5]) / zoom;
+	}
+
+	// Calculate offset to move objects so their center is at target position
+	const offsetX = targetX - clipboardCenterX;
+	const offsetY = targetY - clipboardCenterY;
+
+	for (const objData of clipboard) {
+		// Clone the object data and assign a new ID
+		const newObjData = { ...objData };
+		const newId = uuidv4();
+		newObjData.id = newId;
+
+		// Apply offset to position objects centered on target
+		if (typeof newObjData.left === 'number') newObjData.left += offsetX;
+		if (typeof newObjData.top === 'number') newObjData.top += offsetY;
+
+		// Recreate the object
+		const objects = await util.enlivenObjects([newObjData]);
+		if (objects && objects.length > 0) {
+			const obj = objects[0] as fabric.Object;
+			// @ts-expect-error - Custom id property
+			obj.id = newId;
+
+			// Disable default fabric.js controls and borders - we use custom control points
+			obj.set({ hasControls: false, hasBorders: false });
+
+			// Ensure images use center origin
+			if (obj.type === 'image') {
+				obj.set({ originX: 'center', originY: 'center' });
+			}
+
+			ctx.canvas.add(obj);
+			pastedObjects.push(obj);
+
+			// Send update to other users
+			const sendData =
+				obj.type === 'textbox' ? obj.toObject(['text']) : obj.toObject();
+			// @ts-expect-error - Custom id property
+			sendData.id = obj.id;
+			ctx.sendCanvasUpdate({ type: 'add', object: sendData });
+
+			// Record history for the paste operation
+			if (ctx.history && ctx.userId) {
+				ctx.history.recordAdd(newId, sendData, ctx.userId);
+			}
+		}
+	}
+
+	// Select all pasted objects
+	if (pastedObjects.length > 0) {
+		if (pastedObjects.length === 1) {
+			ctx.canvas.setActiveObject(pastedObjects[0]);
+		} else {
+			const selection = new fabric.ActiveSelection(pastedObjects, {
+				canvas: ctx.canvas,
+			});
+			ctx.canvas.setActiveObject(selection);
+		}
+		ctx.canvas.renderAll();
+	}
+
+	ctx.updateHistoryState?.();
+	return true;
+}
+
+/**
+ * Cuts the currently selected object(s) (copy + delete)
+ */
+export async function cutSelected(
+	ctx: KeyboardShortcutContext,
+): Promise<boolean> {
+	const copied = copySelected(ctx);
+	if (!copied) return false;
+
+	const activeObjects = ctx.canvas.getActiveObjects();
+	if (activeObjects.length === 0) return false;
+
+	// Delete the selected objects
+	const objectsData: Array<{ id: string }> = [];
+	activeObjects.forEach((obj) => {
+		// Skip control points
+		if (ctx.controlPointManager?.isControlPoint(obj)) return;
+
+		// @ts-expect-error - Custom id property
+		const objectId = obj.id;
+		if (objectId) {
+			// Remove control points if applicable
+			ctx.controlPointManager?.removeControlPoints(objectId);
+
+			// Record deletion in history
+			if (ctx.history && ctx.userId) {
+				const objData =
+					obj.type === 'textbox' ? obj.toObject(['text']) : obj.toObject();
+				objData.id = objectId;
+				ctx.history.recordDelete(objectId, objData, ctx.userId);
+			}
+
+			objectsData.push({ id: objectId });
+			ctx.canvas.remove(obj);
+		}
+	});
+
+	ctx.canvas.discardActiveObject();
+	ctx.canvas.renderAll();
+
+	if (objectsData.length > 0) {
+		ctx.sendCanvasUpdate({ type: 'delete', objects: objectsData });
+	}
+
+	ctx.updateHistoryState?.();
+	return true;
+}
+
+/**
+ * Duplicates the currently selected object(s) in place with offset
+ */
+export async function duplicateSelected(
+	ctx: KeyboardShortcutContext,
+): Promise<boolean> {
+	const copied = copySelected(ctx);
+	if (!copied) return false;
+
+	return await pasteFromClipboard(ctx);
+}
+
+/**
+ * Selects all objects on the canvas (excluding control points)
+ * Shows control points for the selected objects
+ */
+export function selectAll(ctx: KeyboardShortcutContext): boolean {
+	const objects = ctx.canvas.getObjects().filter((obj) => {
+		// Skip control points
+		if (ctx.controlPointManager?.isControlPoint(obj)) return false;
+		// Skip objects that aren't selectable
+		if (!obj.selectable) return false;
+		// Skip edge lines (marked with excludeFromExport)
+		if ((obj as unknown as { excludeFromExport?: boolean }).excludeFromExport)
+			return false;
+		return true;
+	});
+
+	if (objects.length === 0) return false;
+
+	// First, remove any existing control points
+	if (ctx.controlPointManager) {
+		const allControlPoints = ctx.controlPointManager.getAllControlPoints();
+		const objectIds = new Set(allControlPoints.map((cp) => cp.objectId));
+		objectIds.forEach((objectId) => {
+			ctx.controlPointManager?.removeControlPoints(objectId);
+		});
+	}
+
+	ctx.canvas.discardActiveObject();
+
+	if (objects.length === 1) {
+		const obj = objects[0];
+		ctx.canvas.setActiveObject(obj);
+		// Add control points for the single selected object
+		if (ctx.controlPointManager) {
+			// @ts-expect-error - Custom id property
+			const objId = obj.id;
+			if (objId) {
+				ctx.controlPointManager.addControlPoints(objId, obj, true);
+			}
+		}
+	} else {
+		// For multiple objects, create an ActiveSelection
+		const selection = new fabric.ActiveSelection(objects, {
+			canvas: ctx.canvas,
+		});
+		ctx.canvas.setActiveObject(selection);
+		// Add control points for each object in the selection
+		if (ctx.controlPointManager) {
+			objects.forEach((obj) => {
+				// @ts-expect-error - Custom id property
+				const objId = obj.id;
+				if (objId) {
+					ctx.controlPointManager?.addControlPoints(objId, obj, true);
+				}
+			});
+		}
+	}
+
+	ctx.canvas.renderAll();
+	return true;
+}
+
+/**
+ * Checks if the current clipboard has content
+ */
+export function hasClipboardContent(): boolean {
+	return clipboard.length > 0;
+}
+
+/**
+ * Clears the clipboard
+ */
+export function clearClipboard(): void {
+	clipboard = [];
+}

--- a/src/lib/components/whiteboard/tools.ts
+++ b/src/lib/components/whiteboard/tools.ts
@@ -134,28 +134,6 @@ export function setLineTool(
 }
 
 /**
- * Set the arrow tool
- */
-export function setArrowTool(
-	canvas: fabric.Canvas | undefined,
-	state: ToolState,
-	clearEraserState: () => void,
-	clearShapeDrawingState: () => void,
-	clearTextDrawingState: () => void,
-): void {
-	state.selectedTool = 'arrow';
-	state.showFloatingMenu = true;
-	clearEraserState();
-	clearShapeDrawingState();
-	clearTextDrawingState();
-	if (!canvas) return;
-	canvas.isDrawingMode = false;
-	canvas.selection = false;
-	canvas.defaultCursor = 'crosshair';
-	canvas.hoverCursor = 'crosshair';
-}
-
-/**
  * Clear eraser state (trail and hovered objects)
  */
 export function clearEraserState(


### PR DESCRIPTION
## Overview

The core canvas rendering and interaction engine for the whiteboard. This is the largest PR in the split and contains all the pure TypeScript logic for drawing, selecting, moving, resizing shapes, undo/redo, and keyboard shortcuts. No Svelte components or routes are included -- this layer is UI-framework-agnostic.

## Changes

### Shape rendering & hit-testing (`src/lib/components/whiteboard/shapes.ts`) -- new file
- `renderShape(ctx, shape)`: draws each shape type (rectangle, ellipse, line, arrow, text, image) onto a Canvas 2D context
- `hitTestShape(shape, point, tolerance)`: returns whether a point lands on a shape (used for selection)
- `getBoundingBox(shape)`: computes the axis-aligned bounding box for any shape type
- `getSnapPoints(shape)`: returns midpoints and corners used for snap-to-shape alignment

### Tool state machine (`src/lib/components/whiteboard/tools.ts`) -- new file
- Manages the active tool and per-tool transient state (e.g. the shape currently being drawn)
- `beginDraw`, `continueDraw`, `endDraw`: lifecycle hooks called by the event handler
- Tool transitions: select, rectangle, ellipse, line, arrow, text, eraser, pan

### Canvas actions (`src/lib/components/whiteboard/canvas-actions.ts`) -- new file
- Pure functions that produce immutable state updates:
  - `addShape`, `updateShape`, `deleteShapes`
  - `moveShapes`, `resizeShape`
  - `bringForward`, `sendBackward`, `bringToFront`, `sendToBack`
  - `duplicateShapes`, `groupShapes` (stub for future)

### Event handling (`src/lib/components/whiteboard/canvas-events.ts`) -- new file
- Translates raw DOM pointer/touch/wheel events into canvas actions and tool transitions
- Handles multi-touch pinch-to-zoom and two-finger pan
- Manages selection box drag, shift-click multi-select, and double-click to edit text

### Undo/redo history (`src/lib/components/whiteboard/canvas-history.ts`) -- new file
- Command-pattern history stack with configurable max depth (default 100 steps)
- `push(snapshot)`, `undo()`, `redo()`, `canUndo`, `canRedo`
- Snapshots are full `CanvasState` copies (immutable, efficient with structural sharing)

### Control points / resize handles (`src/lib/components/whiteboard/control-points.ts`) -- new file
- Computes the 8 resize handle positions around a selected shape's bounding box
- `hitTestControlPoint(point, shape, tolerance)`: returns which handle (if any) is under the cursor
- Applies constrained resizing (shift = maintain aspect ratio, alt = resize from centre)

### Keyboard shortcuts (`src/lib/components/whiteboard/keyboard-shortcuts.ts`) -- new file
- Centralised keyboard binding map (Delete/Backspace to delete, Cmd/Ctrl+Z undo, Cmd/Ctrl+Y redo, Cmd/Ctrl+D duplicate, Escape to deselect, etc.)
- Dispatches to canvas actions and history

### Documentation
- `docs/whiteboard/component-details/shapes.md`
- `docs/whiteboard/component-details/tools.md`
- `docs/whiteboard/component-details/canvas-actions.md`
- `docs/whiteboard/component-details/canvas-events.md`
- `docs/whiteboard/component-details/history.md`
- `docs/whiteboard/component-details/control-points.md`
- `docs/whiteboard/component-details/keyboard-shortcuts.md`

## Context

This is PR **5 of 6** in the whiteboard redesign split. All 6 sub-PRs target the `feat/whiteboard-integration` integration branch. Once all sub-PRs are reviewed and merged, `feat/whiteboard-integration` will be merged to `main` in a single final PR.

| # | Branch | Description |
|---|--------|-------------|
| #66 | `feat/wb-1-misc-fixes` | Misc fixes |
| #67 | `feat/wb-2-socketio` | Socket.IO server infrastructure |
| #68 | `feat/wb-3-db-schema` | Whiteboard DB schema redesign |
| #69 | `feat/wb-4-types-ws-client` | Whiteboard types & WS client |
| **#70** | `feat/wb-5-canvas-engine` | **This PR** -- Canvas engine & control points |
| #71 | `feat/wb-6-ui-routes` | Whiteboard UI components & routes |
