### PR TITLE
feat: add whiteboard UI components and SvelteKit routes

### DIFF
--- a/docs/whiteboard/component-details/integration.md
+++ b/docs/whiteboard/component-details/integration.md
@@ -1,0 +1,404 @@
+# Task Block Integration
+
+This document describes how the whiteboard integrates with the task system, including database schema, service layer, and routing.
+
+## Overview
+
+Each whiteboard is linked to a task block, creating a one-to-one relationship. This enables:
+
+- Multiple whiteboards per task (one per whiteboard task block)
+- Isolated content per whiteboard
+- Automatic cleanup via cascade deletes
+
+## Database Schema
+
+### Whiteboard Table
+
+**File:** `src/lib/server/db/schema/task.ts`
+
+```typescript
+export const whiteboard = pgTable('whiteboard', {
+	id: integer('id').primaryKey().generatedAlwaysAsIdentity({ startWith: 1000 }),
+	taskBlockId: integer('task_block_id')
+		.notNull()
+		.unique() // One whiteboard per task block
+		.references(() => taskBlock.id, { onDelete: 'cascade' }),
+	title: text('title'),
+	...timestamps,
+});
+```
+
+### Whiteboard Objects Table
+
+```typescript
+export const whiteboardObject = pgTable('whiteboard_object', {
+	id: integer('id').primaryKey().generatedAlwaysAsIdentity(),
+	whiteboardId: integer('whiteboard_id')
+		.notNull()
+		.references(() => whiteboard.id, { onDelete: 'cascade' }),
+	objectId: text('object_id').notNull(), // UUID from Fabric.js
+	type: text('type').notNull(), // rect, circle, path, etc.
+	data: jsonb('data').notNull(), // Serialized Fabric.js object
+	zIndex: integer('z_index').default(0),
+	...timestamps,
+});
+```
+
+### Relationships
+
+```
+Task
+├── TaskBlock (type: 'whiteboard')
+│   └── Whiteboard (one-to-one)
+│       └── WhiteboardObjects (one-to-many)
+```
+
+---
+
+## Service Layer
+
+**File:** `src/lib/server/db/service/task.ts`
+
+### Creating a Whiteboard
+
+```typescript
+export async function createWhiteboard(taskBlockId: number, title?: string) {
+	const [whiteboard] = await db
+		.insert(table.whiteboard)
+		.values({ taskBlockId, title })
+		.returning();
+
+	return whiteboard;
+}
+```
+
+### Getting Whiteboard by Task Block
+
+```typescript
+export async function getWhiteboardByTaskBlockId(taskBlockId: number) {
+	const [whiteboard] = await db
+		.select()
+		.from(table.whiteboard)
+		.where(eq(table.whiteboard.taskBlockId, taskBlockId));
+
+	return whiteboard;
+}
+```
+
+### Getting Whiteboard with Task Context
+
+```typescript
+export async function getWhiteboardWithTask(
+	whiteboardId: number,
+	taskId: number,
+) {
+	const [result] = await db
+		.select({
+			whiteboard: table.whiteboard,
+			taskBlock: table.taskBlock,
+			task: table.task,
+		})
+		.from(table.whiteboard)
+		.innerJoin(
+			table.taskBlock,
+			eq(table.whiteboard.taskBlockId, table.taskBlock.id),
+		)
+		.innerJoin(table.task, eq(table.taskBlock.taskId, table.task.id))
+		.where(
+			and(eq(table.whiteboard.id, whiteboardId), eq(table.task.id, taskId)),
+		);
+
+	return result;
+}
+```
+
+### Auto-Creation in Task Block
+
+```typescript
+export async function createTaskBlock(
+	taskId: number,
+	type: TaskBlockType,
+	config?: any,
+) {
+	const [taskBlock] = await db
+		.insert(table.taskBlock)
+		.values({ taskId, type })
+		.returning();
+
+	// Auto-create whiteboard for whiteboard-type blocks
+	if (type === taskBlockTypeEnum.whiteboard) {
+		await createWhiteboard(taskBlock.id, config?.title);
+	}
+
+	return taskBlock;
+}
+```
+
+---
+
+## Object Persistence
+
+### Saving Objects
+
+```typescript
+export async function saveWhiteboardObject(
+	whiteboardId: number,
+	objectId: string,
+	type: string,
+	data: Record<string, unknown>,
+	zIndex?: number,
+) {
+	await db
+		.insert(table.whiteboardObject)
+		.values({ whiteboardId, objectId, type, data, zIndex: zIndex ?? 0 })
+		.onConflictDoUpdate({
+			target: [
+				table.whiteboardObject.whiteboardId,
+				table.whiteboardObject.objectId,
+			],
+			set: { data, zIndex, updatedAt: new Date() },
+		});
+}
+```
+
+### Loading Objects
+
+```typescript
+export async function getWhiteboardObjects(whiteboardId: number) {
+	const objects = await db
+		.select()
+		.from(table.whiteboardObject)
+		.where(eq(table.whiteboardObject.whiteboardId, whiteboardId))
+		.orderBy(table.whiteboardObject.zIndex);
+
+	return objects.map((obj) => obj.data);
+}
+```
+
+### Deleting Objects
+
+```typescript
+export async function deleteWhiteboardObject(
+	whiteboardId: number,
+	objectId: string,
+) {
+	await db
+		.delete(table.whiteboardObject)
+		.where(
+			and(
+				eq(table.whiteboardObject.whiteboardId, whiteboardId),
+				eq(table.whiteboardObject.objectId, objectId),
+			),
+		);
+}
+```
+
+---
+
+## Routing
+
+### Route Structure
+
+```
+/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/whiteboard/[whiteboardId]/
+├── +page.svelte          # Whiteboard canvas
+└── +page.server.ts       # Data loading and validation
+```
+
+### Page Server
+
+**File:** `+page.server.ts`
+
+```typescript
+import { getWhiteboardWithTask } from '$lib/server/db/service/task';
+import { error } from '@sveltejs/kit';
+
+export async function load({ params, locals }) {
+	const whiteboardId = parseInt(params.whiteboardId);
+	const taskId = parseInt(params.taskId);
+
+	// Validate whiteboard belongs to task
+	const result = await getWhiteboardWithTask(whiteboardId, taskId);
+
+	if (!result) {
+		throw error(404, 'Whiteboard not found');
+	}
+
+	return {
+		whiteboard: result.whiteboard,
+		taskBlock: result.taskBlock,
+		task: result.task,
+		user: locals.user,
+	};
+}
+```
+
+### Page Component
+
+**File:** `+page.svelte`
+
+```svelte
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { Canvas } from 'fabric';
+
+	let { data } = $props();
+	const { whiteboard, task, user } = data;
+
+	let canvas: Canvas;
+	let socket: WebSocket;
+
+	onMount(() => {
+		// Initialize canvas
+		canvas = new Canvas('whiteboard-canvas');
+
+		// Initialize WebSocket
+		socket = initSocket(whiteboard.id, user.id);
+		setupSocketHandlers(socket, canvas);
+
+		// Load existing objects
+		socket.emit('join', { whiteboardId: whiteboard.id });
+	});
+
+	onDestroy(() => {
+		socket?.disconnect();
+		canvas?.dispose();
+	});
+</script>
+
+<canvas id="whiteboard-canvas"></canvas>
+```
+
+---
+
+## Task Block Rendering
+
+When rendering a task with whiteboard blocks:
+
+### In Task View
+
+```svelte
+{#each task.blocks as block}
+	{#if block.type === 'whiteboard'}
+		<WhiteboardBlockPreview
+			{block}
+			whiteboardUrl={`/subjects/${subjectOfferingId}/class/${classId}/tasks/${taskId}/whiteboard/${block.whiteboard.id}`}
+		/>
+	{/if}
+{/each}
+```
+
+### WhiteboardBlockPreview Component
+
+```svelte
+<script>
+	let { block, whiteboardUrl } = $props();
+</script>
+
+<div class="whiteboard-block">
+	<h3>{block.whiteboard?.title ?? 'Whiteboard'}</h3>
+	<a href={whiteboardUrl} class="btn"> Open Whiteboard </a>
+</div>
+```
+
+---
+
+## Multiple Whiteboards Per Task
+
+Each whiteboard task block has its own isolated whiteboard:
+
+```
+Task "Physics Lesson"
+├─ Text Block: "Introduction"
+├─ Whiteboard Block #1 → Whiteboard ID 100
+├─ Text Block: "Experiment 1"
+├─ Whiteboard Block #2 → Whiteboard ID 101
+└─ Whiteboard Block #3 → Whiteboard ID 102
+```
+
+### Benefits
+
+1. **Isolation:** Content in each whiteboard is completely separate
+2. **Scalability:** Unlimited whiteboards per task
+3. **Clarity:** Clear one-to-one relationship
+4. **Automatic Cleanup:** Cascade deletes handle orphaned whiteboards
+
+---
+
+## WebSocket Room Scoping
+
+Each whiteboard has its own WebSocket room:
+
+```typescript
+// Server-side
+socket.on('join', ({ whiteboardId }) => {
+	socket.join(`whiteboard:${whiteboardId}`);
+});
+
+// Broadcast only to users in the same whiteboard
+socket.to(`whiteboard:${whiteboardId}`).emit('add', data);
+```
+
+This ensures:
+
+- Users only receive updates for the whiteboard they're viewing
+- Multiple users can work on different whiteboards simultaneously
+- No cross-contamination between whiteboards
+
+---
+
+## Migration Guide
+
+### For Existing Whiteboards
+
+If migrating from task-level whiteboards to task-block-level:
+
+```sql
+-- Add task_block_id column
+ALTER TABLE whiteboard ADD COLUMN task_block_id INTEGER;
+
+-- Link to existing whiteboard task blocks
+UPDATE whiteboard w
+SET task_block_id = (
+  SELECT tb.id FROM task_block tb
+  WHERE tb.task_id = w.task_id
+  AND tb.type = 'whiteboard'
+  LIMIT 1
+);
+
+-- Add constraints
+ALTER TABLE whiteboard
+  ALTER COLUMN task_block_id SET NOT NULL,
+  ADD CONSTRAINT whiteboard_task_block_fk
+    FOREIGN KEY (task_block_id) REFERENCES task_block(id) ON DELETE CASCADE,
+  ADD CONSTRAINT whiteboard_task_block_unique UNIQUE (task_block_id);
+
+-- Remove old task_id column
+ALTER TABLE whiteboard DROP COLUMN task_id;
+```
+
+### For Task Blocks Without Whiteboards
+
+```typescript
+// Ensure all whiteboard task blocks have whiteboards
+const whiteboardBlocks = await db
+	.select()
+	.from(table.taskBlock)
+	.where(eq(table.taskBlock.type, 'whiteboard'));
+
+for (const block of whiteboardBlocks) {
+	const existing = await getWhiteboardByTaskBlockId(block.id);
+	if (!existing) {
+		await createWhiteboard(block.id);
+	}
+}
+```
+
+---
+
+## Source Files
+
+- **Schema**: `src/lib/server/db/schema/task.ts`
+- **Service**: `src/lib/server/db/service/task.ts`
+- **Route**: `src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/whiteboard/[whiteboardId]/`
+- **WebSocket Server**: `src/lib/server/websocket.ts`

--- a/docs/whiteboard/component-details/ui-components.md
+++ b/docs/whiteboard/component-details/ui-components.md
@@ -1,0 +1,415 @@
+# UI Components
+
+This document describes the Svelte components that provide the whiteboard's user interface.
+
+## Component Overview
+
+| Component                             | Purpose                           |
+| ------------------------------------- | --------------------------------- |
+| `whiteboard-toolbar.svelte`           | Main toolbar with tool selection  |
+| `whiteboard-floating-menu.svelte`     | Context-sensitive property editor |
+| `whiteboard-controls.svelte`          | Zoom and undo/redo controls       |
+| `whiteboard-layering-controls.svelte` | Object z-index controls           |
+
+---
+
+## Toolbar Component
+
+**File:** `whiteboard-toolbar.svelte`
+
+The main toolbar provides tool selection and access to primary actions.
+
+### Props
+
+```typescript
+interface Props {
+	selectedTool: WhiteboardTool;
+	onToolChange: (tool: WhiteboardTool) => void;
+	onImageUpload: (file: File) => void;
+	onClear: () => void;
+	disabled?: boolean;
+}
+```
+
+### Tool Buttons
+
+| Tool             | Icon            | Tooltip       |
+| ---------------- | --------------- | ------------- |
+| Select           | `MousePointer2` | Select & Move |
+| Pan              | `Hand`          | Pan Canvas    |
+| Draw             | `Pen`           | Freehand Draw |
+| Line             | `Minus`         | Draw Line     |
+| Shapes (submenu) | `Square`        | Shapes        |
+| Text             | `Type`          | Add Text      |
+| Image            | `ImageIcon`     | Upload Image  |
+| Eraser           | `Eraser`        | Eraser        |
+
+### Shape Submenu
+
+The shapes button opens a dropdown with shape options:
+
+- Rectangle
+- Circle
+- Triangle
+
+### Usage
+
+```svelte
+<WhiteboardToolbar
+	{selectedTool}
+	onToolChange={(tool) => (selectedTool = tool)}
+	onImageUpload={handleImageUpload}
+	onClear={handleClear}
+/>
+```
+
+### Styling
+
+Uses Shadcn UI components:
+
+- `Toggle` for tool buttons
+- `DropdownMenu` for shape submenu
+- `Tooltip` for hover hints
+- `Button` for action buttons
+
+---
+
+## Floating Menu Component
+
+**File:** `whiteboard-floating-menu.svelte`
+
+The floating menu provides context-sensitive property editing based on the selected tool or object.
+
+### Props
+
+```typescript
+interface Props {
+	visible: boolean;
+	selectedTool: WhiteboardTool;
+	selectedObject: fabric.Object | null;
+
+	// Current options
+	textOptions: TextOptions;
+	shapeOptions: ShapeOptions;
+	drawOptions: DrawOptions;
+	lineOptions: LineOptions;
+
+	// Callbacks
+	onTextOptionsChange: (options: TextOptions) => void;
+	onShapeOptionsChange: (options: ShapeOptions) => void;
+	onDrawOptionsChange: (options: DrawOptions) => void;
+	onLineOptionsChange: (options: LineOptions) => void;
+	onCropStart?: () => void;
+}
+```
+
+### Menu Sections by Tool
+
+| Tool/Object     | Menu Contents                                                 |
+| --------------- | ------------------------------------------------------------- |
+| Draw            | Brush type, size, color, opacity                              |
+| Line            | Stroke width, color, dash pattern, opacity                    |
+| Shapes          | Fill color, stroke color, stroke width, dash pattern, opacity |
+| Text            | Font size, family, weight, color, alignment, opacity          |
+| Selected Image  | Crop button                                                   |
+| Selected Object | Relevant properties for that object type                      |
+
+### Color Picker
+
+Uses a custom color picker with preset colors:
+
+```svelte
+<div class="color-grid">
+	{#each presetColors as color}
+		<button
+			class="color-swatch"
+			style="background-color: {color}"
+			class:selected={currentColor === color}
+			on:click={() => selectColor(color)}
+		/>
+	{/each}
+</div>
+<input type="color" bind:value={customColor} />
+```
+
+### Preset Colors
+
+```typescript
+const presetColors = [
+	'#000000',
+	'#FFFFFF',
+	'#FF0000',
+	'#00FF00',
+	'#0000FF',
+	'#FFFF00',
+	'#FF00FF',
+	'#00FFFF',
+	'#FFA500',
+	'#800080',
+	'#008000',
+	'#000080',
+	'#808080',
+	'#C0C0C0',
+	'#4A5568',
+];
+```
+
+### Opacity Slider
+
+```svelte
+<Slider
+	value={[opacity * 100]}
+	max={100}
+	step={1}
+	onValueChange={(v) => setOpacity(v[0] / 100)}
+/>
+```
+
+### Positioning
+
+The menu floats above the canvas, positioned to avoid obscuring the selection:
+
+```typescript
+const menuPosition = $derived.by(() => {
+	if (!selectedObject) return { top: 60, left: 10 };
+
+	// Position above the selected object
+	const bounds = selectedObject.getBoundingRect();
+	return { top: Math.max(10, bounds.top - 50), left: bounds.left };
+});
+```
+
+---
+
+## Controls Component
+
+**File:** `whiteboard-controls.svelte`
+
+Provides zoom controls and undo/redo buttons.
+
+### Props
+
+```typescript
+interface Props {
+	zoom: number;
+	canUndo: boolean;
+	canRedo: boolean;
+	onZoomIn: () => void;
+	onZoomOut: () => void;
+	onResetZoom: () => void;
+	onRecenter: () => void;
+	onUndo: () => void;
+	onRedo: () => void;
+}
+```
+
+### Layout
+
+```
+┌─────────────────────────────────────┐
+│  [Undo] [Redo]  │  [-] 100% [+] [⌂] │
+└─────────────────────────────────────┘
+```
+
+### Zoom Display
+
+```svelte
+<span class="zoom-level">
+	{Math.round(zoom * 100)}%
+</span>
+```
+
+### Button States
+
+```svelte
+<Button variant="ghost" size="icon" disabled={!canUndo} on:click={onUndo}>
+	<Undo2 class="h-4 w-4" />
+</Button>
+```
+
+---
+
+## Layering Controls Component
+
+**File:** `whiteboard-layering-controls.svelte`
+
+Controls for changing object z-index (stacking order).
+
+### Props
+
+```typescript
+interface Props {
+	visible: boolean;
+	onBringToFront: () => void;
+	onMoveForward: () => void;
+	onMoveBackward: () => void;
+	onSendToBack: () => void;
+}
+```
+
+### Buttons
+
+| Button         | Icon           | Action                  |
+| -------------- | -------------- | ----------------------- |
+| Bring to Front | `ChevronsUp`   | Move to top of stack    |
+| Move Forward   | `ChevronUp`    | Move up one level       |
+| Move Backward  | `ChevronDown`  | Move down one level     |
+| Send to Back   | `ChevronsDown` | Move to bottom of stack |
+
+### Visibility
+
+Only shown when an object is selected:
+
+```svelte
+{#if visible}
+	<div class="layering-controls">
+		<!-- buttons -->
+	</div>
+{/if}
+```
+
+---
+
+## Component Composition
+
+### In Page Component
+
+```svelte
+<script>
+	import WhiteboardToolbar from '$lib/components/whiteboard/whiteboard-toolbar.svelte';
+	import WhiteboardFloatingMenu from '$lib/components/whiteboard/whiteboard-floating-menu.svelte';
+	import WhiteboardControls from '$lib/components/whiteboard/whiteboard-controls.svelte';
+	import WhiteboardLayeringControls from '$lib/components/whiteboard/whiteboard-layering-controls.svelte';
+</script>
+
+<div class="whiteboard-container">
+	<!-- Canvas -->
+	<canvas bind:this={canvasElement}></canvas>
+
+	<!-- Toolbar (fixed left) -->
+	<WhiteboardToolbar
+		{selectedTool}
+		onToolChange={handleToolChange}
+		onImageUpload={handleImageUpload}
+		onClear={handleClear}
+	/>
+
+	<!-- Floating Menu (contextual) -->
+	<WhiteboardFloatingMenu
+		visible={showFloatingMenu}
+		{selectedTool}
+		{selectedObject}
+		{textOptions}
+		{shapeOptions}
+		{drawOptions}
+		{lineOptions}
+		onTextOptionsChange={handleTextOptions}
+		onShapeOptionsChange={handleShapeOptions}
+		onDrawOptionsChange={handleDrawOptions}
+		onLineOptionsChange={handleLineOptions}
+		onCropStart={handleCropStart}
+	/>
+
+	<!-- Controls (fixed bottom) -->
+	<WhiteboardControls
+		zoom={currentZoom}
+		{canUndo}
+		{canRedo}
+		onZoomIn={handleZoomIn}
+		onZoomOut={handleZoomOut}
+		onResetZoom={handleResetZoom}
+		onRecenter={handleRecenter}
+		onUndo={performUndo}
+		onRedo={performRedo}
+	/>
+
+	<!-- Layering Controls (when object selected) -->
+	<WhiteboardLayeringControls
+		visible={!!selectedObject}
+		onBringToFront={handleBringToFront}
+		onMoveForward={handleMoveForward}
+		onMoveBackward={handleMoveBackward}
+		onSendToBack={handleSendToBack}
+	/>
+</div>
+```
+
+---
+
+## Styling Patterns
+
+### Fixed Positioning
+
+```css
+.toolbar {
+	position: fixed;
+	left: 1rem;
+	top: 50%;
+	transform: translateY(-50%);
+	z-index: 100;
+}
+
+.controls {
+	position: fixed;
+	bottom: 1rem;
+	left: 50%;
+	transform: translateX(-50%);
+	z-index: 100;
+}
+```
+
+### Glass Effect
+
+```css
+.floating-panel {
+	background: rgba(255, 255, 255, 0.95);
+	backdrop-filter: blur(8px);
+	border-radius: 8px;
+	box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+```
+
+### Dark Mode Support
+
+```css
+:global(.dark) .floating-panel {
+	background: rgba(30, 30, 30, 0.95);
+}
+```
+
+---
+
+## Accessibility
+
+### Keyboard Navigation
+
+- All buttons are keyboard accessible
+- Tool shortcuts shown in tooltips
+- Focus indicators on all interactive elements
+
+### Screen Reader Support
+
+```svelte
+<Button aria-label="Zoom in" title="Zoom in (Ctrl++)">
+	<Plus class="h-4 w-4" />
+</Button>
+```
+
+### Focus Management
+
+```typescript
+// Return focus to canvas after tool selection
+function handleToolChange(tool: WhiteboardTool) {
+	selectedTool = tool;
+	canvasElement?.focus();
+}
+```
+
+---
+
+## Source Files
+
+- **Toolbar**: `src/lib/components/whiteboard/whiteboard-toolbar.svelte`
+- **Floating Menu**: `src/lib/components/whiteboard/whiteboard-floating-menu.svelte`
+- **Controls**: `src/lib/components/whiteboard/whiteboard-controls.svelte`
+- **Layering Controls**: `src/lib/components/whiteboard/whiteboard-layering-controls.svelte`

--- a/src/lib/components/whiteboard/whiteboard-controls.svelte
+++ b/src/lib/components/whiteboard/whiteboard-controls.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/button/button.svelte';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import HomeIcon from '@lucide/svelte/icons/home';
+	import RedoIcon from '@lucide/svelte/icons/redo';
+	import UndoIcon from '@lucide/svelte/icons/undo';
+	import ZoomInIcon from '@lucide/svelte/icons/zoom-in';
+	import ZoomOutIcon from '@lucide/svelte/icons/zoom-out';
+
+	interface Props {
+		currentZoom: number;
+		onZoomIn: () => void;
+		onZoomOut: () => void;
+		onResetZoom: () => void;
+		onRecenterView: () => void;
+		onUndo?: () => void;
+		onRedo?: () => void;
+		canUndo?: boolean;
+		canRedo?: boolean;
+	}
+
+	let {
+		currentZoom,
+		onZoomIn,
+		onZoomOut,
+		onResetZoom,
+		onRecenterView,
+		onUndo,
+		onRedo,
+		canUndo = false,
+		canRedo = false,
+	}: Props = $props();
+</script>
+
+<div class="absolute bottom-8 left-8">
+	<div
+		class="bg-background/20 border-border/50 flex items-center gap-1 rounded-md border px-2 py-1 shadow-sm backdrop-blur-sm"
+	>
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				<Button
+					variant="ghost"
+					size="icon"
+					onclick={onUndo}
+					disabled={!canUndo || !onUndo}
+					class="h-8 w-8"
+				>
+					<UndoIcon />
+				</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>Undo</Tooltip.Content>
+		</Tooltip.Root>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				<Button
+					variant="ghost"
+					size="icon"
+					onclick={onRedo}
+					disabled={!canRedo || !onRedo}
+					class="h-8 w-8"
+				>
+					<RedoIcon />
+				</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>Redo</Tooltip.Content>
+		</Tooltip.Root>
+
+		<div class="bg-border mx-1 h-6 w-px"></div>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				<Button variant="ghost" size="icon" onclick={onZoomOut} class="h-8 w-8">
+					<ZoomOutIcon />
+				</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>Zoom Out</Tooltip.Content>
+		</Tooltip.Root>
+
+		<Button
+			variant="ghost"
+			size="sm"
+			onclick={onResetZoom}
+			class="h-8 px-2 font-mono text-xs"
+		>
+			{Math.round(currentZoom * 100)}%
+		</Button>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				<Button variant="ghost" size="icon" onclick={onZoomIn} class="h-8 w-8">
+					<ZoomInIcon />
+				</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>Zoom In</Tooltip.Content>
+		</Tooltip.Root>
+
+		<div class="bg-border mx-1 h-6 w-px"></div>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				<Button
+					variant="ghost"
+					size="icon"
+					onclick={onRecenterView}
+					class="h-8 w-8"
+				>
+					<HomeIcon />
+				</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>Recenter View</Tooltip.Content>
+		</Tooltip.Root>
+	</div>
+</div>

--- a/src/lib/components/whiteboard/whiteboard-floating-menu.svelte
+++ b/src/lib/components/whiteboard/whiteboard-floating-menu.svelte
@@ -5,14 +5,23 @@
 	import * as Select from '$lib/components/ui/select/index.js';
 	import { Separator } from '$lib/components/ui/separator/index.js';
 	import { Slider } from '$lib/components/ui/slider/index.js';
+	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
+	import ArrowDownToLineIcon from '@lucide/svelte/icons/arrow-down-to-line';
+	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
+	import ArrowUpToLineIcon from '@lucide/svelte/icons/arrow-up-to-line';
+	import CheckIcon from '@lucide/svelte/icons/check';
+	import CropIcon from '@lucide/svelte/icons/crop';
 	import Heading1Icon from '@lucide/svelte/icons/heading-1';
 	import Heading2Icon from '@lucide/svelte/icons/heading-2';
 	import Heading3Icon from '@lucide/svelte/icons/heading-3';
 	import Heading4Icon from '@lucide/svelte/icons/heading-4';
+	import LayersIcon from '@lucide/svelte/icons/layers';
 	import MinusIcon from '@lucide/svelte/icons/minus';
 	import PaletteIcon from '@lucide/svelte/icons/palette';
 	import SlidersIcon from '@lucide/svelte/icons/sliders';
 	import TypeIcon from '@lucide/svelte/icons/type';
+	import XIcon from '@lucide/svelte/icons/x';
+	import WhiteboardLayeringControls from './whiteboard-layering-controls.svelte';
 
 	interface Props {
 		selectedTool: string;
@@ -20,8 +29,16 @@
 		onTextOptionsChange?: (options: TextOptions) => void;
 		onShapeOptionsChange?: (options: ShapeOptions) => void;
 		onDrawOptionsChange?: (options: DrawOptions) => void;
-		onLineArrowOptionsChange?: (options: LineArrowOptions) => void;
+		onLineOptionsChange?: (options: LineOptions) => void;
 		onCanvasInteraction?: () => void;
+		onBringToFront?: () => void;
+		onSendToBack?: () => void;
+		onMoveForward?: () => void;
+		onMoveBackward?: () => void;
+		onStartCrop?: () => void;
+		onApplyCrop?: () => void;
+		onCancelCrop?: () => void;
+		isCropping?: boolean;
 	}
 
 	interface TextOptions {
@@ -49,7 +66,7 @@
 		opacity: number;
 	}
 
-	interface LineArrowOptions {
+	interface LineOptions {
 		strokeWidth: number;
 		strokeColour: string;
 		strokeDashArray: number[];
@@ -62,8 +79,16 @@
 		onTextOptionsChange,
 		onShapeOptionsChange,
 		onDrawOptionsChange,
-		onLineArrowOptionsChange,
+		onLineOptionsChange,
 		onCanvasInteraction,
+		onBringToFront,
+		onSendToBack,
+		onMoveForward,
+		onMoveBackward,
+		onStartCrop,
+		onApplyCrop,
+		onCancelCrop,
+		isCropping = false,
 	}: Props = $props();
 
 	// Track which menu panel to show (independent of selectedTool for editing existing objects)
@@ -100,7 +125,7 @@
 		opacity: 1,
 	});
 
-	let lineArrowOptions = $state<LineArrowOptions>({
+	let lineArrowOptions = $state<LineOptions>({
 		strokeWidth: 2,
 		strokeColour: '#1E1E1E',
 		strokeDashArray: [],
@@ -287,7 +312,7 @@
 		setTimeout(() => (isSyncingFromObject = false), 0);
 	}
 
-	export function updateLineArrowOptions(options: Partial<LineArrowOptions>) {
+	export function updateLineOptions(options: Partial<LineOptions>) {
 		isSyncingFromObject = true;
 		lineArrowOptions = { ...lineArrowOptions, ...options };
 		if (options.strokeWidth !== undefined)
@@ -344,9 +369,19 @@
 		if (
 			!isSyncingFromObject &&
 			(activeMenuPanel === 'line' || activeMenuPanel === 'arrow') &&
-			onLineArrowOptionsChange
+			onLineOptionsChange
 		) {
-			onLineArrowOptionsChange(lineArrowOptions);
+			onLineOptionsChange(lineArrowOptions);
+		}
+	});
+
+	$effect(() => {
+		if (
+			!isSyncingFromObject &&
+			activeMenuPanel === 'image' &&
+			onShapeOptionsChange
+		) {
+			onShapeOptionsChange(shapeOptions);
 		}
 	});
 
@@ -358,7 +393,7 @@
 				activeMenuPanel === 'draw' ||
 				activeMenuPanel === 'eraser' ||
 				activeMenuPanel === 'line' ||
-				activeMenuPanel === 'arrow' ||
+				activeMenuPanel === 'select' ||
 				activeMenuPanel === 'image'),
 	);
 </script>
@@ -368,60 +403,60 @@
 		class="absolute top-1/2 left-8 z-20 flex -translate-y-1/2 transform gap-2"
 	>
 		<Card.Root
-			class="bg-background/20 border-border/50 max-w-80 min-w-64 backdrop-blur-sm"
+			class="bg-background/20 border-border/50 max-w-64 min-w-56 backdrop-blur-sm"
 		>
 			{#if activeMenuPanel === 'text'}
-				<Card.Header class="pb-3">
-					<Card.Title class="flex items-center gap-2 text-sm">
-						<TypeIcon />
+				<Card.Header class="pb-0">
+					<Card.Title class="flex items-center gap-1.5 text-xs">
+						<TypeIcon class="h-3.5 w-3.5" />
 						Text Options
 					</Card.Title>
 				</Card.Header>
-				<Card.Content class="space-y-4">
+				<Card.Content class="space-y-3 pt-2 pb-3">
 					<!-- Font Size -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Font Size</Label>
-						<div class="flex gap-2">
+						<div class="flex gap-1.5">
 							<Button
 								variant={fontSizeValue === 32 ? 'default' : 'outline'}
 								size="sm"
 								onclick={() => (fontSizeValue = 32)}
-								class="flex h-8 flex-1 items-center justify-center"
+								class="flex h-7 flex-1 items-center justify-center"
 							>
-								<Heading1Icon />
+								<Heading1Icon class="h-4 w-4" />
 							</Button>
 							<Button
 								variant={fontSizeValue === 24 ? 'default' : 'outline'}
 								size="sm"
 								onclick={() => (fontSizeValue = 24)}
-								class="flex h-8 flex-1 items-center justify-center"
+								class="flex h-7 flex-1 items-center justify-center"
 							>
-								<Heading2Icon />
+								<Heading2Icon class="h-4 w-4" />
 							</Button>
 							<Button
 								variant={fontSizeValue === 16 ? 'default' : 'outline'}
 								size="sm"
 								onclick={() => (fontSizeValue = 16)}
-								class="flex h-8 flex-1 items-center justify-center"
+								class="flex h-7 flex-1 items-center justify-center"
 							>
-								<Heading3Icon />
+								<Heading3Icon class="h-4 w-4" />
 							</Button>
 							<Button
 								variant={fontSizeValue === 12 ? 'default' : 'outline'}
 								size="sm"
 								onclick={() => (fontSizeValue = 12)}
-								class="flex h-8 flex-1 items-center justify-center"
+								class="flex h-7 flex-1 items-center justify-center"
 							>
-								<Heading4Icon />
+								<Heading4Icon class="h-4 w-4" />
 							</Button>
 						</div>
 					</div>
 
 					<!-- Font Family -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Font Family</Label>
 						<Select.Root type="single" bind:value={textOptions.fontFamily}>
-							<Select.Trigger class="h-8">
+							<Select.Trigger class="h-7 text-xs">
 								{textOptions.fontFamily}
 							</Select.Trigger>
 							<Select.Content>
@@ -433,10 +468,10 @@
 					</div>
 
 					<!-- Font Weight -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Font Weight</Label>
 						<Select.Root type="single" bind:value={textOptions.fontWeight}>
-							<Select.Trigger class="h-8">
+							<Select.Trigger class="h-7 text-xs">
 								{fontWeights.find((w) => w.value === textOptions.fontWeight)
 									?.label || 'Normal'}
 							</Select.Trigger>
@@ -451,12 +486,12 @@
 					<Separator />
 
 					<!-- Text Colour -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Text Colour</Label>
 						<div class="mb-2 flex flex-wrap items-center gap-1">
 							{#each commonColours as colour}
 								<button
-									class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {textOptions.colour ===
+									class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {textOptions.colour ===
 									colour
 										? 'border-primary ring-primary/20 ring-2'
 										: 'border-border hover:border-primary/50'}"
@@ -475,7 +510,7 @@
 
 							<!-- Expanded colours toggle button -->
 							<button
-								class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {showExpandedColours &&
+								class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {showExpandedColours &&
 								expandedColoursFor === 'text'
 									? 'border-primary ring-primary/20 ring-2'
 									: 'border-border hover:border-primary/50'}"
@@ -501,7 +536,7 @@
 					<Separator />
 
 					<!-- Opacity -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Opacity</Label>
 						<div class="flex items-center gap-3">
 							<Slider
@@ -517,24 +552,34 @@
 							>
 						</div>
 					</div>
+
+					<Separator />
+
+					<!-- Layering Controls -->
+					<WhiteboardLayeringControls
+						{onBringToFront}
+						{onSendToBack}
+						{onMoveForward}
+						{onMoveBackward}
+					/>
 				</Card.Content>
 			{:else if activeMenuPanel === 'shapes'}
-				<Card.Header class="pb-3">
-					<Card.Title class="flex items-center gap-2 text-sm">
-						<SlidersIcon />
+				<Card.Header class="pb-0">
+					<Card.Title class="flex items-center gap-1.5 text-xs">
+						<SlidersIcon class="h-3.5 w-3.5" />
 						Shape Options
 					</Card.Title>
 				</Card.Header>
-				<Card.Content class="space-y-4">
+				<Card.Content class="space-y-3 pt-2 pb-3">
 					<!-- Stroke Width -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Stroke Width</Label>
-						<div class="flex gap-2">
+						<div class="flex gap-1.5">
 							<Button
 								variant={strokeWidthValue === 1 ? 'default' : 'outline'}
 								size="sm"
 								onclick={() => (strokeWidthValue = 1)}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
 								<MinusIcon class="h-3 w-3" strokeWidth={1} />
 							</Button>
@@ -542,7 +587,7 @@
 								variant={strokeWidthValue === 2 ? 'default' : 'outline'}
 								size="sm"
 								onclick={() => (strokeWidthValue = 2)}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
 								<MinusIcon strokeWidth={4} />
 							</Button>
@@ -550,17 +595,17 @@
 								variant={strokeWidthValue === 3 ? 'default' : 'outline'}
 								size="sm"
 								onclick={() => (strokeWidthValue = 3)}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
-								<MinusIcon class="h-5 w-5" strokeWidth={7} />
+								<MinusIcon class="h-4 w-4" strokeWidth={7} />
 							</Button>
 						</div>
 					</div>
 
 					<!-- Border Style -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Border Style</Label>
-						<div class="flex gap-2">
+						<div class="flex gap-1.5">
 							<Button
 								variant={JSON.stringify(shapeOptions.strokeDashArray) ===
 								JSON.stringify([])
@@ -568,9 +613,9 @@
 									: 'outline'}
 								size="sm"
 								onclick={() => (shapeOptions.strokeDashArray = [])}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
-								<MinusIcon />
+								<MinusIcon class="h-4 w-4" />
 							</Button>
 							<Button
 								variant={JSON.stringify(shapeOptions.strokeDashArray) ===
@@ -579,7 +624,7 @@
 									: 'outline'}
 								size="sm"
 								onclick={() => (shapeOptions.strokeDashArray = [5, 5])}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
 								<svg width="16" height="16" viewBox="0 0 16 16">
 									<line
@@ -600,7 +645,7 @@
 									: 'outline'}
 								size="sm"
 								onclick={() => (shapeOptions.strokeDashArray = [2, 2])}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
 								<svg width="16" height="16" viewBox="0 0 16 16">
 									<line
@@ -620,12 +665,12 @@
 					<Separator />
 
 					<!-- Stroke Colour -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Stroke Colour</Label>
 						<div class="mb-2 flex flex-wrap items-center gap-1">
 							{#each commonColours as colour}
 								<button
-									class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {shapeOptions.strokeColour ===
+									class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {shapeOptions.strokeColour ===
 									colour
 										? 'border-primary ring-primary/20 ring-2'
 										: 'border-border hover:border-primary/50'}"
@@ -644,7 +689,7 @@
 
 							<!-- Expanded colours toggle button -->
 							<button
-								class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {showExpandedColours &&
+								class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {showExpandedColours &&
 								expandedColoursFor === 'stroke'
 									? 'border-primary ring-primary/20 ring-2'
 									: 'border-border hover:border-primary/50'}"
@@ -670,9 +715,9 @@
 					<Separator />
 
 					<!-- Fill Colour -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Fill Colour</Label>
-						<div class="mb-2 flex gap-2">
+						<div class="mb-2 flex gap-1.5">
 							<Button
 								variant={shapeOptions.fillColour === 'transparent'
 									? 'default'
@@ -687,7 +732,7 @@
 						<div class="mb-2 flex flex-wrap items-center gap-1">
 							{#each commonColours as colour}
 								<button
-									class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {shapeOptions.fillColour ===
+									class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {shapeOptions.fillColour ===
 									colour
 										? 'border-primary ring-primary/20 ring-2'
 										: 'border-border hover:border-primary/50'}"
@@ -706,7 +751,7 @@
 
 							<!-- Expanded colours toggle button -->
 							<button
-								class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {showExpandedColours &&
+								class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {showExpandedColours &&
 								expandedColoursFor === 'fill'
 									? 'border-primary ring-primary/20 ring-2'
 									: 'border-border hover:border-primary/50'}"
@@ -732,7 +777,7 @@
 					<Separator />
 
 					<!-- Opacity -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Opacity</Label>
 						<div class="flex items-center gap-3">
 							<Slider
@@ -748,24 +793,34 @@
 							>
 						</div>
 					</div>
+
+					<Separator />
+
+					<!-- Layering Controls -->
+					<WhiteboardLayeringControls
+						{onBringToFront}
+						{onSendToBack}
+						{onMoveForward}
+						{onMoveBackward}
+					/>
 				</Card.Content>
 			{:else if activeMenuPanel === 'draw' || activeMenuPanel === 'eraser'}
-				<Card.Header class="pb-3">
-					<Card.Title class="flex items-center gap-2 text-sm">
-						<PaletteIcon />
+				<Card.Header class="pb-0">
+					<Card.Title class="flex items-center gap-1.5 text-xs">
+						<PaletteIcon class="h-3.5 w-3.5" />
 						Draw Options
 					</Card.Title>
 				</Card.Header>
-				<Card.Content class="space-y-4">
+				<Card.Content class="space-y-3 pt-2 pb-3">
 					<!-- Brush Size -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Brush Size</Label>
-						<div class="flex gap-2">
+						<div class="flex gap-1.5">
 							<Button
 								variant={brushSizeValue === 2 ? 'default' : 'outline'}
 								size="sm"
 								onclick={() => (brushSizeValue = 2)}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
 								<MinusIcon class="h-3 w-3" strokeWidth={1} />
 							</Button>
@@ -773,7 +828,7 @@
 								variant={brushSizeValue === 6 ? 'default' : 'outline'}
 								size="sm"
 								onclick={() => (brushSizeValue = 6)}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
 								<MinusIcon strokeWidth={4} />
 							</Button>
@@ -781,9 +836,9 @@
 								variant={brushSizeValue === 12 ? 'default' : 'outline'}
 								size="sm"
 								onclick={() => (brushSizeValue = 12)}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
-								<MinusIcon class="h-5 w-5" strokeWidth={7} />
+								<MinusIcon class="h-4 w-4" strokeWidth={7} />
 							</Button>
 						</div>
 					</div>
@@ -791,12 +846,12 @@
 					<Separator />
 
 					<!-- Brush Colour -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Brush Colour</Label>
 						<div class="mb-2 flex flex-wrap items-center gap-1">
 							{#each commonColours as colour}
 								<button
-									class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {drawOptions.brushColour ===
+									class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {drawOptions.brushColour ===
 									colour
 										? 'border-primary ring-primary/20 ring-2'
 										: 'border-border hover:border-primary/50'}"
@@ -815,7 +870,7 @@
 
 							<!-- Expanded colours toggle button -->
 							<button
-								class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {showExpandedColours &&
+								class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {showExpandedColours &&
 								expandedColoursFor === 'brush'
 									? 'border-primary ring-primary/20 ring-2'
 									: 'border-border hover:border-primary/50'}"
@@ -841,7 +896,7 @@
 					<Separator />
 
 					<!-- Opacity -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Opacity</Label>
 						<div class="flex items-center gap-3">
 							<Slider
@@ -857,18 +912,28 @@
 							>
 						</div>
 					</div>
+
+					<Separator />
+
+					<!-- Layering Controls -->
+					<WhiteboardLayeringControls
+						{onBringToFront}
+						{onSendToBack}
+						{onMoveForward}
+						{onMoveBackward}
+					/>
 				</Card.Content>
 			{:else if activeMenuPanel === 'line' || activeMenuPanel === 'arrow'}
-				<Card.Header class="pb-3">
-					<Card.Title class="flex items-center gap-2 text-sm">
+				<Card.Header class="pb-0">
+					<Card.Title class="flex items-center gap-1.5 text-xs">
 						{#if activeMenuPanel === 'line'}
-							<MinusIcon />
+							<MinusIcon class="h-3.5 w-3.5" />
 							Line Options
 						{:else}
 							<!-- Using arrow right icon for arrow tool -->
 							<svg
-								width="24"
-								height="24"
+								width="14"
+								height="14"
 								fill="none"
 								stroke="currentColor"
 								viewBox="0 0 24 24"
@@ -885,18 +950,18 @@
 						{/if}
 					</Card.Title>
 				</Card.Header>
-				<Card.Content class="space-y-4">
+				<Card.Content class="space-y-3 pt-2 pb-3">
 					<!-- Stroke Width -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Stroke Width</Label>
-						<div class="flex gap-2">
+						<div class="flex gap-1.5">
 							<Button
 								variant={lineArrowStrokeWidthValue === 1
 									? 'default'
 									: 'outline'}
 								size="sm"
 								onclick={() => (lineArrowStrokeWidthValue = 1)}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
 								<MinusIcon class="h-3 w-3" strokeWidth={1} />
 							</Button>
@@ -906,7 +971,7 @@
 									: 'outline'}
 								size="sm"
 								onclick={() => (lineArrowStrokeWidthValue = 3)}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
 								<MinusIcon strokeWidth={3} />
 							</Button>
@@ -916,9 +981,9 @@
 									: 'outline'}
 								size="sm"
 								onclick={() => (lineArrowStrokeWidthValue = 6)}
-								class="flex h-10 w-10 items-center justify-center"
+								class="flex h-8 w-8 items-center justify-center"
 							>
-								<MinusIcon class="h-5 w-5" strokeWidth={6} />
+								<MinusIcon class="h-4 w-4" strokeWidth={6} />
 							</Button>
 						</div>
 					</div>
@@ -926,12 +991,12 @@
 					<Separator />
 
 					<!-- Stroke Colour -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Colour</Label>
 						<div class="mb-2 flex flex-wrap items-center gap-1">
 							{#each commonColours as colour}
 								<button
-									class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {lineArrowOptions.strokeColour ===
+									class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {lineArrowOptions.strokeColour ===
 									colour
 										? 'border-primary ring-primary/20 ring-2'
 										: 'border-border hover:border-primary/50'}"
@@ -950,7 +1015,7 @@
 
 							<!-- Expanded colours toggle button -->
 							<button
-								class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {showExpandedColours &&
+								class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {showExpandedColours &&
 								expandedColoursFor === 'line'
 									? 'border-primary ring-primary/20 ring-2'
 									: 'border-border hover:border-primary/50'}"
@@ -976,7 +1041,7 @@
 					<Separator />
 
 					<!-- Line Style -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Line Style</Label>
 						<div class="flex gap-2">
 							<Button
@@ -1005,7 +1070,7 @@
 					<Separator />
 
 					<!-- Opacity -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Opacity</Label>
 						<div class="flex items-center gap-3">
 							<Slider
@@ -1021,17 +1086,74 @@
 							>
 						</div>
 					</div>
+
+					<Separator />
+
+					<!-- Layering Controls -->
+					<WhiteboardLayeringControls
+						{onBringToFront}
+						{onSendToBack}
+						{onMoveForward}
+						{onMoveBackward}
+					/>
 				</Card.Content>
 			{:else if activeMenuPanel === 'image'}
-				<Card.Header class="pb-3">
-					<Card.Title class="flex items-center gap-2 text-sm">
-						<SlidersIcon />
+				<Card.Header class="pb-0">
+					<Card.Title class="flex items-center gap-1.5 text-xs">
+						<SlidersIcon class="h-3.5 w-3.5" />
 						Image Options
 					</Card.Title>
 				</Card.Header>
-				<Card.Content class="space-y-4">
+				<Card.Content class="space-y-3 pt-2 pb-3">
+					<!-- Crop Controls -->
+					{#if isCropping}
+						<div class="space-y-1.5">
+							<Label class="text-xs font-medium">Crop Mode</Label>
+							<p class="text-muted-foreground text-xs">
+								Drag the handles to adjust the crop area.
+							</p>
+							<div class="flex gap-2">
+								<Button
+									variant="default"
+									size="sm"
+									onclick={onApplyCrop}
+									class="flex flex-1 items-center justify-center gap-2"
+								>
+									<CheckIcon class="h-4 w-4" />
+									<span>Apply</span>
+								</Button>
+								<Button
+									variant="outline"
+									size="sm"
+									onclick={onCancelCrop}
+									class="flex flex-1 items-center justify-center gap-2"
+								>
+									<XIcon class="h-4 w-4" />
+									<span>Cancel</span>
+								</Button>
+							</div>
+						</div>
+					{:else}
+						<!-- Crop Button -->
+						<div class="space-y-1.5">
+							<Label class="text-xs font-medium">Crop</Label>
+							<Button
+								variant="outline"
+								size="sm"
+								onclick={onStartCrop}
+								class="flex w-full items-center justify-center gap-2"
+								disabled={!onStartCrop}
+							>
+								<CropIcon class="h-4 w-4" />
+								<span>Crop Image</span>
+							</Button>
+						</div>
+					{/if}
+
+					<Separator />
+
 					<!-- Opacity -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Opacity</Label>
 						<div class="flex items-center gap-3">
 							<Slider
@@ -1047,6 +1169,71 @@
 							>
 						</div>
 					</div>
+
+					<Separator />
+
+					<!-- Layering Controls -->
+					<WhiteboardLayeringControls
+						{onBringToFront}
+						{onSendToBack}
+						{onMoveForward}
+						{onMoveBackward}
+					/>
+				</Card.Content>
+			{:else if activeMenuPanel === 'select'}
+				<Card.Header class="pb-0">
+					<Card.Title class="flex items-center gap-1.5 text-xs">
+						<LayersIcon class="h-3.5 w-3.5" />
+						Object Options
+					</Card.Title>
+				</Card.Header>
+				<Card.Content class="space-y-3 pt-2 pb-3">
+					<!-- Layering Controls -->
+					<div class="space-y-1.5">
+						<Label class="text-xs font-medium">Layering</Label>
+						<div class="grid grid-cols-2 gap-2">
+							<Button
+								variant="outline"
+								size="sm"
+								onclick={onBringToFront}
+								class="flex items-center justify-center gap-2"
+								disabled={!onBringToFront}
+							>
+								<ArrowUpToLineIcon class="h-4 w-4" />
+								<span>To Front</span>
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onclick={onSendToBack}
+								class="flex items-center justify-center gap-2"
+								disabled={!onSendToBack}
+							>
+								<ArrowDownToLineIcon class="h-4 w-4" />
+								<span>To Back</span>
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onclick={onMoveForward}
+								class="flex items-center justify-center gap-2"
+								disabled={!onMoveForward}
+							>
+								<ArrowUpIcon class="h-4 w-4" />
+								<span>Forward</span>
+							</Button>
+							<Button
+								variant="outline"
+								size="sm"
+								onclick={onMoveBackward}
+								class="flex items-center justify-center gap-2"
+								disabled={!onMoveBackward}
+							>
+								<ArrowDownIcon class="h-4 w-4" />
+								<span>Backward</span>
+							</Button>
+						</div>
+					</div>
 				</Card.Content>
 			{/if}
 		</Card.Root>
@@ -1054,24 +1241,24 @@
 		<!-- Side Panel for Expanded Colours -->
 		{#if showExpandedColours}
 			<Card.Root
-				class="bg-background/20 border-border/50 w-64 backdrop-blur-sm"
+				class="bg-background/20 border-border/50 w-56 backdrop-blur-sm"
 			>
-				<Card.Header class="pb-3">
-					<Card.Title class="flex items-center gap-2 text-sm">
-						<PaletteIcon />
+				<Card.Header class="pb-0">
+					<Card.Title class="flex items-center gap-1.5 text-xs">
+						<PaletteIcon class="h-3.5 w-3.5" />
 						Colour Palette
 					</Card.Title>
 				</Card.Header>
-				<Card.Content class="space-y-4">
+				<Card.Content class="space-y-3 pt-2 pb-0">
 					<!-- Colour Grid -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-xs font-medium">Colours</Label>
 						<div class="space-y-1">
 							{#each colourPalette as row}
 								<div class="flex gap-1">
 									{#each row as colour}
 										<button
-											class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {selectedColourFamily ===
+											class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {selectedColourFamily ===
 											colour
 												? 'border-primary ring-primary/20 ring-2'
 												: 'border-border hover:border-primary/50'}"
@@ -1104,7 +1291,7 @@
 					</div>
 
 					<!-- Shades -->
-					<div class="space-y-2">
+					<div class="space-y-1.5">
 						<Label class="text-muted-foreground text-xs font-medium"
 							>Shades</Label
 						>
@@ -1116,7 +1303,7 @@
 							<div class="flex gap-1">
 								{#each colourShades[selectedColourFamily] as shade}
 									<button
-										class="h-10 w-10 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {(expandedColoursFor ===
+										class="h-8 w-8 rounded-md border-2 p-0.5 transition-colors hover:scale-105 {(expandedColoursFor ===
 											'text' &&
 											textOptions.colour === shade) ||
 										(expandedColoursFor === 'stroke' &&

--- a/src/lib/components/whiteboard/whiteboard-layering-controls.svelte
+++ b/src/lib/components/whiteboard/whiteboard-layering-controls.svelte
@@ -1,0 +1,93 @@
+<script lang="ts">
+	import { Button } from '$lib/components/ui/button/index.js';
+	import { Label } from '$lib/components/ui/label/index.js';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
+	import ArrowDownIcon from '@lucide/svelte/icons/arrow-down';
+	import ArrowDownToLineIcon from '@lucide/svelte/icons/arrow-down-to-line';
+	import ArrowUpIcon from '@lucide/svelte/icons/arrow-up';
+	import ArrowUpToLineIcon from '@lucide/svelte/icons/arrow-up-to-line';
+
+	interface Props {
+		onBringToFront?: () => void;
+		onSendToBack?: () => void;
+		onMoveForward?: () => void;
+		onMoveBackward?: () => void;
+	}
+
+	let { onBringToFront, onSendToBack, onMoveForward, onMoveBackward }: Props =
+		$props();
+</script>
+
+<!-- Layering Controls -->
+<div class="space-y-2">
+	<Label class="text-xs font-medium">Layering</Label>
+	<div class="flex gap-1">
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				<Button
+					variant="outline"
+					size="icon"
+					onclick={onBringToFront}
+					class="h-8 w-8"
+					disabled={!onBringToFront}
+				>
+					<ArrowUpToLineIcon />
+				</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>
+				<p>Bring to Front</p>
+			</Tooltip.Content>
+		</Tooltip.Root>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				<Button
+					variant="outline"
+					size="icon"
+					onclick={onMoveForward}
+					class="h-8 w-8"
+					disabled={!onMoveForward}
+				>
+					<ArrowUpIcon />
+				</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>
+				<p>Move Forward</p>
+			</Tooltip.Content>
+		</Tooltip.Root>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				<Button
+					variant="outline"
+					size="icon"
+					onclick={onMoveBackward}
+					class="h-8 w-8"
+					disabled={!onMoveBackward}
+				>
+					<ArrowDownIcon />
+				</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>
+				<p>Move Backward</p>
+			</Tooltip.Content>
+		</Tooltip.Root>
+
+		<Tooltip.Root>
+			<Tooltip.Trigger>
+				<Button
+					variant="outline"
+					size="icon"
+					onclick={onSendToBack}
+					class="h-8 w-8"
+					disabled={!onSendToBack}
+				>
+					<ArrowDownToLineIcon />
+				</Button>
+			</Tooltip.Trigger>
+			<Tooltip.Content>
+				<p>Send to Back</p>
+			</Tooltip.Content>
+		</Tooltip.Root>
+	</div>
+</div>

--- a/src/lib/components/whiteboard/whiteboard-toolbar.svelte
+++ b/src/lib/components/whiteboard/whiteboard-toolbar.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/button/button.svelte';
-	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
-	import ArrowRightIcon from '@lucide/svelte/icons/arrow-right';
 	import CircleIcon from '@lucide/svelte/icons/circle';
 	import EraseIcon from '@lucide/svelte/icons/eraser';
 	import HandIcon from '@lucide/svelte/icons/hand';
@@ -17,11 +15,11 @@
 
 	interface Props {
 		selectedTool: string;
+		currentShapeType?: string;
 		onSelectTool: () => void;
 		onPanTool: () => void;
 		onDrawTool: () => void;
 		onLineTool: () => void;
-		onArrowTool: () => void;
 		onAddShape: (shapeType: string) => void;
 		onAddText: () => void;
 		onAddImage: () => void;
@@ -31,11 +29,11 @@
 
 	let {
 		selectedTool,
+		currentShapeType = '',
 		onSelectTool,
 		onPanTool,
 		onDrawTool,
 		onLineTool,
-		onArrowTool,
 		onAddShape,
 		onAddText,
 		onAddImage,
@@ -111,54 +109,57 @@
 				<Tooltip.Content>Draw Line</Tooltip.Content>
 			</Tooltip.Root>
 
-			<!-- Arrow Tool -->
+			<!-- Rectangle Tool -->
 			<Tooltip.Root>
 				<Tooltip.Trigger>
 					<Button
-						variant={selectedTool === 'arrow' ? 'default' : 'ghost'}
+						variant={selectedTool === 'shapes' &&
+						currentShapeType === 'rectangle'
+							? 'default'
+							: 'ghost'}
 						size="icon"
-						onclick={onArrowTool}
+						onclick={() => onAddShape('rectangle')}
 						class="h-9 w-9"
 					>
-						<ArrowRightIcon />
+						<SquareIcon />
 					</Button>
 				</Tooltip.Trigger>
-				<Tooltip.Content>Draw Arrow</Tooltip.Content>
+				<Tooltip.Content>Rectangle</Tooltip.Content>
 			</Tooltip.Root>
 
-			<!-- Shapes Dropdown -->
+			<!-- Circle Tool -->
 			<Tooltip.Root>
 				<Tooltip.Trigger>
-					<DropdownMenu.Root>
-						<DropdownMenu.Trigger>
-							{#snippet child({ props })}
-								<Button
-									{...props}
-									variant={selectedTool === 'shapes' ? 'default' : 'ghost'}
-									size="icon"
-									class="h-9 w-9"
-								>
-									<SquareIcon />
-								</Button>
-							{/snippet}
-						</DropdownMenu.Trigger>
-						<DropdownMenu.Content>
-							<DropdownMenu.Item onclick={() => onAddShape('rectangle')}>
-								<SquareIcon />
-								Rectangle
-							</DropdownMenu.Item>
-							<DropdownMenu.Item onclick={() => onAddShape('circle')}>
-								<CircleIcon />
-								Circle
-							</DropdownMenu.Item>
-							<DropdownMenu.Item onclick={() => onAddShape('triangle')}>
-								<TriangleIcon />
-								Triangle
-							</DropdownMenu.Item>
-						</DropdownMenu.Content>
-					</DropdownMenu.Root>
+					<Button
+						variant={selectedTool === 'shapes' && currentShapeType === 'circle'
+							? 'default'
+							: 'ghost'}
+						size="icon"
+						onclick={() => onAddShape('circle')}
+						class="h-9 w-9"
+					>
+						<CircleIcon />
+					</Button>
 				</Tooltip.Trigger>
-				<Tooltip.Content>Add Shapes</Tooltip.Content>
+				<Tooltip.Content>Circle</Tooltip.Content>
+			</Tooltip.Root>
+
+			<!-- Triangle Tool -->
+			<Tooltip.Root>
+				<Tooltip.Trigger>
+					<Button
+						variant={selectedTool === 'shapes' &&
+						currentShapeType === 'triangle'
+							? 'default'
+							: 'ghost'}
+						size="icon"
+						onclick={() => onAddShape('triangle')}
+						class="h-9 w-9"
+					>
+						<TriangleIcon />
+					</Button>
+				</Tooltip.Trigger>
+				<Tooltip.Content>Triangle</Tooltip.Content>
 			</Tooltip.Root>
 
 			<!-- Text Tool -->

--- a/src/routes/api/tasks/blocks/+server.ts
+++ b/src/routes/api/tasks/blocks/+server.ts
@@ -1,6 +1,7 @@
 import { taskBlockTypeEnum } from '$lib/enums';
 import {
 	createTaskBlock,
+	createWhiteboard,
 	deleteTaskBlock,
 	updateTaskBlock,
 } from '$lib/server/db/service';
@@ -43,6 +44,14 @@ export async function POST({ request }: { request: Request }) {
 			config: config as Record<string, unknown>,
 			index,
 		});
+
+		// If this is a whiteboard block, create the whiteboard entry
+		if (type === 'whiteboard') {
+			await createWhiteboard({
+				taskBlockId: block.id,
+				title: (config as { title?: string }).title || null,
+			});
+		}
 
 		return json({ block });
 	} catch (error) {

--- a/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/+page.svelte
+++ b/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/+page.svelte
@@ -701,9 +701,13 @@
 									/>
 								{:else if block.type === taskBlockTypeEnum.whiteboard}
 									<BlockWhiteboard
+										blockId={block.id}
 										config={block.config as BlockWhiteboardConfig}
 										onConfigUpdate={async (config) =>
 											await handleConfigUpdate(block, config)}
+										whiteboardMap={data.whiteboardMap}
+										whiteboardLockStates={data.whiteboardLockStates}
+										isTeacher={data.user.type === userTypeEnum.teacher}
 										{viewMode}
 									/>
 								{:else if block.type === taskBlockTypeEnum.choice}

--- a/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/client.ts
+++ b/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/client.ts
@@ -1,3 +1,4 @@
+import { invalidateAll } from '$app/navigation';
 import type { taskBlockTypeEnum } from '$lib/enums';
 
 const API_BASE = '/api/tasks';
@@ -37,6 +38,11 @@ export async function createBlock(request: {
 
 	if (!response.ok) {
 		throw new Error(data.error || 'Failed to create block');
+	}
+
+	// If a whiteboard block was created, invalidate to reload whiteboardMap
+	if (request.type === 'whiteboard') {
+		await invalidateAll();
 	}
 
 	return data;

--- a/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/components/block-whiteboard.svelte
+++ b/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/components/block-whiteboard.svelte
@@ -1,75 +1,152 @@
 <script lang="ts">
+	import { browser } from '$app/environment';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import Input from '$lib/components/ui/input/input.svelte';
 	import Label from '$lib/components/ui/label/label.svelte';
+	import * as Tooltip from '$lib/components/ui/tooltip/index.js';
 	import { ViewMode, type WhiteboardBlockProps } from '$lib/schema/task';
 	import PresentationIcon from '@lucide/svelte/icons/presentation';
+	import { io, type Socket } from 'socket.io-client';
+	import { onDestroy, onMount } from 'svelte';
+	import { toast } from 'svelte-sonner';
 
-	let { config, onConfigUpdate, viewMode }: WhiteboardBlockProps = $props();
+	let {
+		blockId,
+		config,
+		onConfigUpdate,
+		viewMode,
+		whiteboardMap,
+		whiteboardLockStates,
+		isTeacher,
+	}: WhiteboardBlockProps & {
+		whiteboardMap?: Record<number, number>;
+		whiteboardLockStates?: Record<number, boolean>;
+		isTeacher?: boolean;
+	} = $props();
 
 	const { taskId, subjectOfferingId, subjectOfferingClassId } = $derived(
 		page.params,
 	);
 
-	const createWhiteboard = async () => {
+	const whiteboardId = $derived(whiteboardMap?.[blockId] ?? null);
+	let isLocked = $state(false);
+	let isTogglingLock = $state(false);
+	let socket: Socket | null = $state(null);
+
+	// Update isLocked when whiteboardId or lockStates change
+	$effect(() => {
+		if (whiteboardId && whiteboardLockStates) {
+			isLocked = whiteboardLockStates[whiteboardId] ?? false;
+		}
+	});
+
+	// Setup Socket.IO connection for broadcasting lock changes
+	onMount(() => {
+		if (!browser || !whiteboardId) return;
+
+		// Connect to Socket.IO server
+		socket = io({ path: '/socket.io/', transports: ['websocket', 'polling'] });
+
+		socket.on('connect', () => {
+			// Initialize with whiteboardId
+			socket?.emit('init', { whiteboardId });
+		});
+
+		socket.on('connect_error', (error) => {
+			console.error('Socket.IO connection error:', error);
+		});
+	});
+
+	onDestroy(() => {
+		if (socket) {
+			socket.disconnect();
+		}
+	});
+
+	const openWhiteboard = () => {
+		if (!whiteboardId) {
+			console.error('No whiteboard ID available');
+			return;
+		}
+
+		const url = `/subjects/${subjectOfferingId}/class/${subjectOfferingClassId}/tasks/${taskId}/whiteboard/${whiteboardId}`;
+		goto(url);
+	};
+
+	const toggleLock = async () => {
+		if (!whiteboardId || isTogglingLock) return;
+
+		isTogglingLock = true;
+
 		try {
-			const response = await fetch('/api/whiteboards', {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					taskId: parseInt(taskId!),
-					title: config.title || null,
-				}),
-			});
+			const formData = new FormData();
+			formData.append('whiteboardId', whiteboardId.toString());
 
-			if (response.ok) {
-				const data = await response.json();
-				config.whiteboardId = data.whiteboardId;
-				return data.whiteboardId;
+			const response = await fetch(
+				`/subjects/${subjectOfferingId}/class/${subjectOfferingClassId}/tasks/${taskId}?/toggleWhiteboardLock`,
+				{ method: 'POST', body: formData },
+			);
+
+			const result = await response.json();
+
+			if (result.type === 'success' && result.data) {
+				let actionData =
+					typeof result.data === 'string'
+						? JSON.parse(result.data)
+						: result.data;
+
+				// Handle devalue format
+				if (Array.isArray(actionData)) {
+					const reconstructed = {
+						type: actionData[1],
+						data: { isLocked: actionData[3] },
+					};
+					actionData = reconstructed;
+				}
+
+				if (
+					actionData.type === 'success' &&
+					actionData.data?.isLocked !== undefined
+				) {
+					const newLockState = actionData.data.isLocked;
+
+					// Update local state immediately for reactivity
+					isLocked = newLockState;
+
+					// Also update the shared state
+					if (whiteboardLockStates) {
+						whiteboardLockStates[whiteboardId] = newLockState;
+					}
+
+					// Broadcast lock state change via Socket.IO to all connected clients
+					if (socket && socket.connected) {
+						const lockMessage = newLockState ? 'lock' : 'unlock';
+						socket.emit(lockMessage, {
+							isLocked: newLockState,
+							whiteboardId: whiteboardId,
+						});
+					}
+
+					// Show toast notification
+					if (newLockState) {
+						toast.success('Whiteboard locked', {
+							description: 'Students can now only view and pan the whiteboard',
+						});
+					} else {
+						toast.success('Whiteboard unlocked', {
+							description: 'Students can now edit the whiteboard',
+						});
+					}
+				}
 			}
-		} catch (error) {
-			console.error('Failed to create whiteboard:', error);
-		}
-		return null;
-	};
-
-	const saveChanges = async () => {
-		let currentWhiteboardId = config.whiteboardId;
-
-		if (!currentWhiteboardId) {
-			currentWhiteboardId = await createWhiteboard();
-		}
-
-		const newConfig = {
-			whiteboardId: currentWhiteboardId,
-			title: config.title || '',
-		};
-
-		await onConfigUpdate(newConfig);
-	};
-
-	const openWhiteboard = async () => {
-		let currentWhiteboardId = config.whiteboardId;
-
-		if (!currentWhiteboardId) {
-			currentWhiteboardId = await createWhiteboard();
-			if (currentWhiteboardId) {
-				const newConfig = {
-					whiteboardId: currentWhiteboardId,
-					title: config.title || '',
-				};
-				await onConfigUpdate(newConfig);
-			}
-		}
-
-		if (currentWhiteboardId) {
-			const url = `/subjects/${subjectOfferingId}/class/${subjectOfferingClassId}/tasks/${taskId}/whiteboard/${currentWhiteboardId}`;
-			goto(url);
-		} else {
-			console.error('Failed to get whiteboard ID');
+		} catch (err) {
+			console.error('Lock toggle failed:', err);
+			toast.error('Failed to toggle lock', { description: 'Please try again' });
+		} finally {
+			isTogglingLock = false;
 		}
 	};
 </script>
@@ -100,34 +177,78 @@
 					/>
 				</div>
 				<p class="text-muted-foreground text-sm">
-					Access the configured whiteboard through preview mode.
+					Each whiteboard block has its own unique whiteboard. Access it through
+					preview mode.
 				</p>
 			</Card.Content>
 		</Card.Root>
-	{:else if config.whiteboardId}
-		<div class="rounded-lg border p-6 text-center">
-			<PresentationIcon class="text-muted-foreground mx-auto mb-3 h-12 w-12" />
-			<h3 class="mb-2 text-lg font-semibold break-words">
-				{config.title || 'Interactive Whiteboard'}
-			</h3>
-			<Button class="mt-6 w-full" onclick={openWhiteboard}
-				>Open Whiteboard</Button
-			>
+	{:else if whiteboardId}
+		<div class="rounded-lg border p-6">
+			<div class="text-center">
+				<PresentationIcon
+					class="text-muted-foreground mx-auto mb-3 h-12 w-12"
+				/>
+				<h3 class="mb-2 text-lg font-semibold break-words">
+					{config.title || 'Interactive Whiteboard'}
+				</h3>
+			</div>
+			<div class="mt-6 flex items-center gap-2">
+				<Button class="flex-1" onclick={openWhiteboard}>Open Whiteboard</Button>
+				{#if isTeacher}
+					<Tooltip.Root>
+						<Tooltip.Trigger>
+							<Button
+								variant="ghost"
+								size="icon"
+								onclick={toggleLock}
+								disabled={isTogglingLock}
+							>
+								{#if isLocked}
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										width="20"
+										height="20"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+										<path d="M7 11V7a5 5 0 0 1 10 0v4" />
+									</svg>
+								{:else}
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										width="20"
+										height="20"
+										viewBox="0 0 24 24"
+										fill="none"
+										stroke="currentColor"
+										stroke-width="2"
+										stroke-linecap="round"
+										stroke-linejoin="round"
+									>
+										<rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
+										<path d="M7 11V7a5 5 0 0 1 9.9-1" />
+									</svg>
+								{/if}
+							</Button>
+						</Tooltip.Trigger>
+						<Tooltip.Content>
+							{isLocked ? 'Unlock Whiteboard' : 'Lock Whiteboard'}
+						</Tooltip.Content>
+					</Tooltip.Root>
+				{/if}
+			</div>
 		</div>
 	{:else}
-		<button
-			type="button"
-			class="focus:ring-primary flex h-32 w-full cursor-pointer items-center justify-center rounded-lg border border-dashed focus:ring-2 focus:outline-none"
-			onclick={openWhiteboard}
-			aria-label="Create and open whiteboard"
-		>
-			<div class="pointer-events-none text-center">
-				<PresentationIcon class="text-muted-foreground mx-auto h-12 w-12" />
-				<p class="text-muted-foreground mt-2 text-sm">No whiteboard created</p>
-				<p class="text-muted-foreground text-xs">
-					Click to create and open whiteboard
-				</p>
-			</div>
-		</button>
+		<div class="rounded-lg border p-6 text-center">
+			<PresentationIcon class="text-muted-foreground mx-auto mb-3 h-12 w-12" />
+			<p class="text-muted-foreground">
+				Whiteboard not found. Please try refreshing the page.
+			</p>
+		</div>
 	{/if}
 </div>

--- a/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/whiteboard/[whiteboardId]/lock-handler.ts
+++ b/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/whiteboard/[whiteboardId]/lock-handler.ts
@@ -1,0 +1,41 @@
+// Lock handler for whiteboard
+export function applyLockState(
+	canvas: any,
+	locked: boolean,
+	isTeacher: boolean,
+) {
+	if (!canvas) return;
+
+	if (locked && !isTeacher) {
+		// Student in locked mode - view only
+		canvas.isDrawingMode = false;
+		canvas.selection = false;
+		canvas.forEachObject((obj: any) => {
+			obj.selectable = false;
+			obj.evented = false;
+		});
+		canvas.discardActiveObject();
+		canvas.renderAll();
+	} else {
+		// Teacher or unlocked - normal mode
+		canvas.selection = true;
+		canvas.forEachObject((obj: any) => {
+			obj.selectable = true;
+			obj.evented = true;
+		});
+		canvas.renderAll();
+	}
+}
+
+export function handleLockMessage(
+	data: any,
+	isLocked: { value: boolean },
+	canvas: any,
+	isTeacher: boolean,
+	applyLock: typeof applyLockState,
+) {
+	if (data.type === 'lock' || data.type === 'unlock') {
+		isLocked.value = data.isLocked;
+		applyLock(canvas, isLocked.value, isTeacher);
+	}
+}

--- a/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/whiteboard/ws/+server.ts
+++ b/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/whiteboard/ws/+server.ts
@@ -1,0 +1,206 @@
+import {
+	clearWhiteboard,
+	deleteWhiteboardObject,
+	deleteWhiteboardObjects,
+	getWhiteboardObjects,
+	saveWhiteboardObject,
+	updateWhiteboardObject,
+} from '$lib/server/db/service';
+
+// Store peer subscriptions with their whiteboardId
+const peerWhiteboards = new Map<any, number>();
+
+export const socket = {
+	async open(peer: any) {
+		// Wait for client to send init message with whiteboardId
+		// Don't load anything until we know which whiteboard to use
+	},
+
+	async message(peer: any, message: any) {
+		const parsedMessage = JSON.parse(String(message));
+		const whiteboardId =
+			parsedMessage.whiteboardId || peerWhiteboards.get(peer);
+
+		if (!whiteboardId) {
+			peer.send(
+				JSON.stringify({
+					type: 'error',
+					message: 'No whiteboard ID specified',
+				}),
+			);
+			return;
+		}
+
+		try {
+			if (parsedMessage.type === 'init') {
+				// Handle whiteboard initialization with specific ID
+				const newWhiteboardId = parsedMessage.whiteboardId;
+				if (newWhiteboardId && newWhiteboardId !== peerWhiteboards.get(peer)) {
+					// Unsubscribe from old whiteboard
+					const oldWhiteboardId = peerWhiteboards.get(peer);
+					if (oldWhiteboardId) {
+						peer.unsubscribe(`whiteboard-${oldWhiteboardId}`);
+					}
+
+					// Subscribe to new whiteboard
+					peerWhiteboards.set(peer, newWhiteboardId);
+					peer.subscribe(`whiteboard-${newWhiteboardId}`);
+
+					// Send current state of new whiteboard
+					try {
+						const objects = await getWhiteboardObjects(newWhiteboardId);
+						const whiteboardObjects = objects.map((obj) => ({
+							id: obj.objectId,
+							...(obj.objectData as Record<string, unknown>),
+						}));
+
+						peer.send(
+							JSON.stringify({
+								type: 'load',
+								whiteboardId: newWhiteboardId,
+								whiteboard: { objects: whiteboardObjects },
+							}),
+						);
+					} catch (error) {
+						console.error('Failed to load whiteboard from database:', error);
+					}
+				}
+				return;
+			} else if (parsedMessage.type === 'clear') {
+				await clearWhiteboard(whiteboardId);
+				peer.publish(
+					`whiteboard-${whiteboardId}`,
+					JSON.stringify({ type: 'clear', whiteboardId }),
+				);
+			} else if (
+				parsedMessage.type === 'add' ||
+				parsedMessage.type === 'create'
+			) {
+				const newObject = parsedMessage.object;
+
+				await saveWhiteboardObject({
+					objectId: newObject.id,
+					objectData: newObject,
+					whiteboardId,
+				});
+
+				peer.publish(
+					`whiteboard-${whiteboardId}`,
+					JSON.stringify({ type: 'add', object: newObject, whiteboardId }),
+				);
+			} else if (
+				parsedMessage.type === 'remove' ||
+				parsedMessage.type === 'delete'
+			) {
+				if (parsedMessage.objects) {
+					const objectsToRemove = parsedMessage.objects;
+					const objectIds = objectsToRemove.map(
+						(obj: { id: string }) => obj.id,
+					);
+
+					await deleteWhiteboardObjects(objectIds, whiteboardId);
+
+					peer.publish(
+						`whiteboard-${whiteboardId}`,
+						JSON.stringify({
+							type: 'delete',
+							objects: objectsToRemove,
+							whiteboardId,
+						}),
+					);
+				} else if (parsedMessage.object) {
+					const objectToRemove = parsedMessage.object;
+
+					await deleteWhiteboardObject(objectToRemove.id, whiteboardId);
+
+					peer.publish(
+						`whiteboard-${whiteboardId}`,
+						JSON.stringify({
+							type: 'delete',
+							objects: [objectToRemove],
+							whiteboardId,
+						}),
+					);
+				}
+			} else if (
+				parsedMessage.type === 'update' ||
+				parsedMessage.type === 'modify'
+			) {
+				const updatedObject = parsedMessage.object;
+				const isLiveUpdate = parsedMessage.live || false; // Flag for live vs final updates
+
+				// For live updates, skip database writes to improve performance
+				if (!isLiveUpdate) {
+					await updateWhiteboardObject(
+						updatedObject.id,
+						updatedObject,
+						whiteboardId,
+					);
+				}
+
+				// Always broadcast the update to other connected clients
+				peer.publish(
+					`whiteboard-${whiteboardId}`,
+					JSON.stringify({
+						type: 'modify',
+						object: updatedObject,
+						whiteboardId,
+					}),
+				);
+			} else if (parsedMessage.type === 'layer') {
+				// Handle layering changes
+				const layeredObject = parsedMessage.object;
+				const action = parsedMessage.action;
+
+				// Update the object in the database to reflect the new z-index
+				await updateWhiteboardObject(
+					layeredObject.id,
+					layeredObject,
+					whiteboardId,
+				);
+
+				// Broadcast the layering change to other clients
+				peer.publish(
+					`whiteboard-${whiteboardId}`,
+					JSON.stringify({
+						type: 'layer',
+						object: layeredObject,
+						action: action,
+						whiteboardId,
+					}),
+				);
+			} else if (
+				parsedMessage.type === 'lock' ||
+				parsedMessage.type === 'unlock'
+			) {
+				// Handle lock/unlock events (broadcasted from API endpoint)
+				// Just forward to all connected clients
+				peer.publish(
+					`whiteboard-${whiteboardId}`,
+					JSON.stringify({
+						type: parsedMessage.type,
+						isLocked: parsedMessage.isLocked,
+						whiteboardId,
+					}),
+				);
+			}
+		} catch (error) {
+			console.error('Database operation failed:', error);
+			peer.send(
+				JSON.stringify({
+					type: 'error',
+					message: 'Failed to persist changes',
+					whiteboardId,
+				}),
+			);
+		}
+	},
+
+	close(peer: any) {
+		const whiteboardId = peerWhiteboards.get(peer);
+		if (whiteboardId) {
+			peer.unsubscribe(`whiteboard-${whiteboardId}`);
+			peerWhiteboards.delete(peer);
+		}
+	},
+};

--- a/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/new/+page.server.ts
+++ b/src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/new/+page.server.ts
@@ -68,6 +68,7 @@ export const actions = {
 					taskId: task.id,
 					subjectOfferingClassId: subjectOfferingClassIdInt,
 					authorId: user.id,
+					curriculumItemId: parseInt(form.data.taskTopicId, 10),
 					week: form.data.week ?? null,
 					due: form.data.dueDate ?? null,
 				});


### PR DESCRIPTION
## Overview

The final piece of the whiteboard redesign: Svelte UI components, the whiteboard page route, the Socket.IO upgrade endpoint, lock handling, and integration with the existing task block system. This PR ties together all the previous layers into a fully working collaborative whiteboard feature.

## Changes

### Whiteboard UI components (new Svelte files)
- **`whiteboard-toolbar.svelte`** -- top toolbar with tool buttons (select, shapes, text, eraser, pan), zoom controls, and undo/redo buttons. Bound to the active tool in `CanvasState`.
- **`whiteboard-controls.svelte`** -- right-side property panel: stroke colour, fill colour, stroke width, font size, opacity sliders. Updates shape styles in real time.
- **`whiteboard-floating-menu.svelte`** -- context menu that appears when one or more shapes are selected: copy, delete, bring forward/back, lock/unlock.
- **`whiteboard-layering-controls.svelte`** -- dedicated layer order controls (bring to front, send to back, step forward, step back).

### Whiteboard page route
- **`src/routes/subjects/[subjectOfferingId]/class/[subjectOfferingClassId]/tasks/[taskId]/whiteboard/[whiteboardId]/+page.svelte`** -- the main whiteboard canvas page. Initialises `CanvasState`, connects to the Socket.IO room, renders the `<canvas>` element, attaches event handlers from `canvas-events.ts`, and re-renders via `requestAnimationFrame` loop when state changes.
- **`+page.server.ts`** -- loads the whiteboard and its shapes from the database, validates access, and returns initial state to the client.

### Socket.IO server endpoint
- **`src/routes/subjects/.../whiteboard/ws/+server.ts`** -- SvelteKit server endpoint that handles the Socket.IO connection upgrade for the whiteboard room.

### Lock handler
- **`lock-handler.ts`** -- manages per-shape optimistic locking so two users cannot simultaneously edit the same shape. Emits lock-acquired/lock-released events over Socket.IO.

### Task block integration
- **`src/routes/subjects/[subjectOfferingId]/class/.../tasks/[taskId]/+page.svelte`** -- updated task page to render whiteboard blocks alongside existing block types
- **`src/routes/subjects/[subjectOfferingId]/class/.../tasks/[taskId]/+page.server.ts`** -- updated server load to fetch whiteboard block data
- **`src/lib/components/whiteboard/block-whiteboard.svelte`** -- the task block component that embeds a whiteboard preview and links to the full whiteboard page

### API
- **`src/routes/api/tasks/blocks/+server.ts`** -- updated blocks API to support creating, updating, and deleting whiteboard blocks

### Documentation
- `docs/whiteboard/component-details/ui-components.md`
- `docs/whiteboard/component-details/integration.md`

## Context

This is PR **6 of 6** in the whiteboard redesign split. All 6 sub-PRs target the `feat/whiteboard-integration` integration branch. Once all sub-PRs are reviewed and merged, `feat/whiteboard-integration` will be merged to `main` in a single final PR.

**Note:** PRs #66-#70 introduce isolated layers that do not individually produce a working UI. This PR is where everything comes together into a working feature.

| # | Branch | Description |
|---|--------|-------------|
| #66 | `feat/wb-1-misc-fixes` | Misc fixes |
| #67 | `feat/wb-2-socketio` | Socket.IO server infrastructure |
| #68 | `feat/wb-3-db-schema` | Whiteboard DB schema redesign |
| #69 | `feat/wb-4-types-ws-client` | Whiteboard types & WS client |
| #70 | `feat/wb-5-canvas-engine` | Canvas engine & control points |
| **#71** | `feat/wb-6-ui-routes` | **This PR** -- Whiteboard UI components & routes |
